### PR TITLE
:sparkles: Fixed bug on failure event emitter and added support for external logger as well as async local storage for log tracing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -37,8 +36,7 @@
     "node_modules/@aws-crypto/crc32/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "peer": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
@@ -115,18 +113,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.271.0.tgz",
-      "integrity": "sha512-sP4RvP0fvmMySS6hV/EKMrTJ9KVMH85rn1EKvmJ3nBTKRKiR8GQUS/vX+dhLYu+3jRs2P6cY2zjGzpaOcII91w==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@aws-sdk/client-lambda": {
       "version": "3.369.0",
@@ -606,28 +592,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@aws-sdk/client-sns": {
       "version": "3.369.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.369.0.tgz",
@@ -1102,1670 +1066,426 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sns/node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.271.0.tgz",
-      "integrity": "sha512-46IsI9GI1EJgzBOSP6+/+JY5uI8MZHxJ3GE0eCnZQKD9knJw31xfExVFjGDFOYY5cfkdUz/YXUhRRPieP6sxJw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.370.0.tgz",
+      "integrity": "sha512-HaF+Jb5dKtvv2uA5WhtPMPM4d6vczHGKV1x/CRFJv2NDwHJX6E84RZ+74008SCjdA3C1RqvErrjw0iSwYyN7CA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.271.0",
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/credential-provider-node": "3.271.0",
-        "@aws-sdk/fetch-http-handler": "3.271.0",
-        "@aws-sdk/hash-node": "3.271.0",
-        "@aws-sdk/invalid-dependency": "3.271.0",
-        "@aws-sdk/md5-js": "3.271.0",
-        "@aws-sdk/middleware-content-length": "3.271.0",
-        "@aws-sdk/middleware-endpoint": "3.271.0",
-        "@aws-sdk/middleware-host-header": "3.271.0",
-        "@aws-sdk/middleware-logger": "3.271.0",
-        "@aws-sdk/middleware-recursion-detection": "3.271.0",
-        "@aws-sdk/middleware-retry": "3.271.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.271.0",
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/middleware-signing": "3.271.0",
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/middleware-user-agent": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/node-http-handler": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/smithy-client": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-        "@aws-sdk/util-defaults-mode-node": "3.271.0",
-        "@aws-sdk/util-endpoints": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "@aws-sdk/util-user-agent-browser": "3.271.0",
-        "@aws-sdk/util-user-agent-node": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sts": "3.370.0",
+        "@aws-sdk/credential-provider-node": "3.370.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.370.0",
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/md5-js": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.271.0.tgz",
-      "integrity": "sha512-auWPqok8yJ2UOQfNrvfLNmvf0tRAbekaZRvZZ2TzTKTKd7yz6V7Y5+AdRnp01FHoOQ+8A7MHTXtp7h7i9qltKw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.370.0.tgz",
+      "integrity": "sha512-0Ty1iHuzNxMQtN7nahgkZr4Wcu1XvqGfrQniiGdKKif9jG/4elxsQPiydRuQpFqN6b+bg7wPP7crFP1uTxx2KQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/fetch-http-handler": "3.271.0",
-        "@aws-sdk/hash-node": "3.271.0",
-        "@aws-sdk/invalid-dependency": "3.271.0",
-        "@aws-sdk/middleware-content-length": "3.271.0",
-        "@aws-sdk/middleware-endpoint": "3.271.0",
-        "@aws-sdk/middleware-host-header": "3.271.0",
-        "@aws-sdk/middleware-logger": "3.271.0",
-        "@aws-sdk/middleware-recursion-detection": "3.271.0",
-        "@aws-sdk/middleware-retry": "3.271.0",
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/middleware-user-agent": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/node-http-handler": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/smithy-client": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-        "@aws-sdk/util-defaults-mode-node": "3.271.0",
-        "@aws-sdk/util-endpoints": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "@aws-sdk/util-user-agent-browser": "3.271.0",
-        "@aws-sdk/util-user-agent-node": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.271.0.tgz",
-      "integrity": "sha512-pYN8r0slDbP0v2q0SyLKihE2PPfbsF/hH7+11w6OpAMvSGvfm+m8R5rB49Szy3bkDudR0MhLpD6D76yoy9ckrQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.370.0.tgz",
+      "integrity": "sha512-jAYOO74lmVXylQylqkPrjLzxvUnMKw476JCUTvCO6Q8nv3LzCWd76Ihgv/m9Q4M2Tbqi1iP2roVK5bstsXzEjA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/fetch-http-handler": "3.271.0",
-        "@aws-sdk/hash-node": "3.271.0",
-        "@aws-sdk/invalid-dependency": "3.271.0",
-        "@aws-sdk/middleware-content-length": "3.271.0",
-        "@aws-sdk/middleware-endpoint": "3.271.0",
-        "@aws-sdk/middleware-host-header": "3.271.0",
-        "@aws-sdk/middleware-logger": "3.271.0",
-        "@aws-sdk/middleware-recursion-detection": "3.271.0",
-        "@aws-sdk/middleware-retry": "3.271.0",
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/middleware-user-agent": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/node-http-handler": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/smithy-client": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-        "@aws-sdk/util-defaults-mode-node": "3.271.0",
-        "@aws-sdk/util-endpoints": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "@aws-sdk/util-user-agent-browser": "3.271.0",
-        "@aws-sdk/util-user-agent-node": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.271.0.tgz",
-      "integrity": "sha512-dsLGj1Q3EdqLYNjm0WpeK07wv8Xed6R+tCf+x4KMWOAVAnz72XuoZNWDI2NvACubAniEhpFycMmf39Y6NCAkLg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.370.0.tgz",
+      "integrity": "sha512-utFxOPWIzbN+3kc415Je2o4J72hOLNhgR2Gt5EnRSggC3yOnkC4GzauxG8n7n5gZGBX45eyubHyPOXLOIyoqQA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/credential-provider-node": "3.271.0",
-        "@aws-sdk/fetch-http-handler": "3.271.0",
-        "@aws-sdk/hash-node": "3.271.0",
-        "@aws-sdk/invalid-dependency": "3.271.0",
-        "@aws-sdk/middleware-content-length": "3.271.0",
-        "@aws-sdk/middleware-endpoint": "3.271.0",
-        "@aws-sdk/middleware-host-header": "3.271.0",
-        "@aws-sdk/middleware-logger": "3.271.0",
-        "@aws-sdk/middleware-recursion-detection": "3.271.0",
-        "@aws-sdk/middleware-retry": "3.271.0",
-        "@aws-sdk/middleware-sdk-sts": "3.271.0",
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/middleware-signing": "3.271.0",
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/middleware-user-agent": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/node-http-handler": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/smithy-client": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-        "@aws-sdk/util-defaults-mode-node": "3.271.0",
-        "@aws-sdk/util-endpoints": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "@aws-sdk/util-user-agent-browser": "3.271.0",
-        "@aws-sdk/util-user-agent-node": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.271.0.tgz",
-      "integrity": "sha512-sP4RvP0fvmMySS6hV/EKMrTJ9KVMH85rn1EKvmJ3nBTKRKiR8GQUS/vX+dhLYu+3jRs2P6cY2zjGzpaOcII91w==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.271.0.tgz",
-      "integrity": "sha512-auWPqok8yJ2UOQfNrvfLNmvf0tRAbekaZRvZZ2TzTKTKd7yz6V7Y5+AdRnp01FHoOQ+8A7MHTXtp7h7i9qltKw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/fetch-http-handler": "3.271.0",
-        "@aws-sdk/hash-node": "3.271.0",
-        "@aws-sdk/invalid-dependency": "3.271.0",
-        "@aws-sdk/middleware-content-length": "3.271.0",
-        "@aws-sdk/middleware-endpoint": "3.271.0",
-        "@aws-sdk/middleware-host-header": "3.271.0",
-        "@aws-sdk/middleware-logger": "3.271.0",
-        "@aws-sdk/middleware-recursion-detection": "3.271.0",
-        "@aws-sdk/middleware-retry": "3.271.0",
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/middleware-user-agent": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/node-http-handler": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/smithy-client": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-        "@aws-sdk/util-defaults-mode-node": "3.271.0",
-        "@aws-sdk/util-endpoints": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "@aws-sdk/util-user-agent-browser": "3.271.0",
-        "@aws-sdk/util-user-agent-node": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.271.0.tgz",
-      "integrity": "sha512-pYN8r0slDbP0v2q0SyLKihE2PPfbsF/hH7+11w6OpAMvSGvfm+m8R5rB49Szy3bkDudR0MhLpD6D76yoy9ckrQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/fetch-http-handler": "3.271.0",
-        "@aws-sdk/hash-node": "3.271.0",
-        "@aws-sdk/invalid-dependency": "3.271.0",
-        "@aws-sdk/middleware-content-length": "3.271.0",
-        "@aws-sdk/middleware-endpoint": "3.271.0",
-        "@aws-sdk/middleware-host-header": "3.271.0",
-        "@aws-sdk/middleware-logger": "3.271.0",
-        "@aws-sdk/middleware-recursion-detection": "3.271.0",
-        "@aws-sdk/middleware-retry": "3.271.0",
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/middleware-user-agent": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/node-http-handler": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/smithy-client": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-        "@aws-sdk/util-defaults-mode-node": "3.271.0",
-        "@aws-sdk/util-endpoints": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "@aws-sdk/util-user-agent-browser": "3.271.0",
-        "@aws-sdk/util-user-agent-node": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.271.0.tgz",
-      "integrity": "sha512-lKZGcDYe8us2Ep7/AjhLyMMTq0NuVt+M+L1eedBGRuGkx/Hrvn4qwlIvSXZhiodoQVa+Wr1zIah3Z06U0dTaZA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.271.0.tgz",
-      "integrity": "sha512-u3KsjtGBo1SA9HQAVxfA7zHWirlrdKsqsMpnp4eOtixZLoz1e2EytrR5XZem2HND0lzjrUrEPGDPp5OpDtcHxw==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.271.0.tgz",
-      "integrity": "sha512-zIclMwXbJeNev74+0tbxLpEO2Js7AhqvR2Msiytz05kOXRyk61NMEavtKRp1YxD2KMptONnvNlbWbNW2rrRDnw==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.271.0",
-        "@aws-sdk/credential-provider-imds": "3.271.0",
-        "@aws-sdk/credential-provider-process": "3.271.0",
-        "@aws-sdk/credential-provider-sso": "3.271.0",
-        "@aws-sdk/credential-provider-web-identity": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.271.0.tgz",
-      "integrity": "sha512-hfdJ+8QM5xXEm4mF4AfIy6T1fVb2zTaUVm5PfPDHtkggVM1L+QSywEkZ2lUqQZMLbbatJqVLy2EMA91k5kjVrA==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.271.0",
-        "@aws-sdk/credential-provider-imds": "3.271.0",
-        "@aws-sdk/credential-provider-ini": "3.271.0",
-        "@aws-sdk/credential-provider-process": "3.271.0",
-        "@aws-sdk/credential-provider-sso": "3.271.0",
-        "@aws-sdk/credential-provider-web-identity": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.271.0.tgz",
-      "integrity": "sha512-Q1HIZYTUYLVe0cNc3HbtFOFzgo3A6PHcmT62T8XClAhFRhkOsJ/KWUybjm8col49/1uqIjKA20E7P7f5Qnn2TQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.271.0.tgz",
-      "integrity": "sha512-TIvsv4xXTME6UsH7g05IzVDCLujaMmgv45A0KcAyM/J/HvFQ9IBOBdyKGU5zIawPvCWXiqQqZs/kDchdB2sjXA==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/token-providers": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.271.0.tgz",
-      "integrity": "sha512-GD1mg7fMA3ESl0jdzH/+keZHV9Fue/iaGMIWNCUm7M9dOJo0JZbDNzSaMtxZnuA6xtkvw3FiLH6ZxPt0V+7wmg==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.271.0.tgz",
-      "integrity": "sha512-yc0YgKioACFcfs7RPtVHRlpsyYJNdEHkqiWtnRSXG0vuZHAkfvwzchrDK4bizMblnmEV/xbl495ZqDlVbQ0c9A==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/querystring-builder": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/hash-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.271.0.tgz",
-      "integrity": "sha512-VamRhkGo2uaVe7KhQhdTqpp9y5JKSFNE3yCUZf/o6lGwL9BgBpBiVqzwCePtas7hAphAaOYvefIwx0XLaCeQ1w==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.271.0.tgz",
-      "integrity": "sha512-ZN8JmN/t+4UTHkQ6wdod2KKLfJcewLS3D/0iZLnvvOzLlymhcHp9QY8t//RObF+WxnlWeCAvZttoMl/a2MLpYQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.271.0.tgz",
-      "integrity": "sha512-bmfqCvjFcowa6jLltJIkGHNXY599Fu9ROoMtYjQiD2ixWHmUpS0I/VivcxXL3uES2qhehxYXyJFyCt7aqRQqcA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.271.0.tgz",
-      "integrity": "sha512-pibhIe57e68NAfDUY5c7d9zo6WfNwgfclwtrK0nV3OXw9psNeCLGLC1YbzsTun49tm0ICSmkHgmqfsXAVe4HWA==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.271.0.tgz",
-      "integrity": "sha512-sp75WZDzDui/Wr3GnQH/db4DXgVdOpKdRQddDsRuULzri8HeJlhMW+JCP+sP0kQmkO06Dagxv1tSmENUxFhPaQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.271.0.tgz",
-      "integrity": "sha512-mB/vayfsuc20PySSpbbQ56CPER/RAZF5oGkwGuwFI3bY+VwRun0MOnx3yHj7Ja2DN1ZEOH1Hzrb0eUgREozmHw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.271.0.tgz",
-      "integrity": "sha512-prrS/YL3GdLODqVBSgxvpUfo9aPBLB3Km5wNBdbhjjN0rI1RqjD+0LquVgaz6C1VU/I8cYbnxrFYtQVcdgnWpg==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.271.0.tgz",
-      "integrity": "sha512-yCBXmxbFGT/4czTi+e4z7lV0nbMWctvvzOtl1ssBiG0LagijIhK4KUp0KTnqDJ+yBqxMpd7wNJ1B0NdS0re6Fw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/service-error-classification": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.271.0.tgz",
-      "integrity": "sha512-louPEKEZP2TtTavMwg4k6IJjEbXC6xV05Wtb4I+ZKzjupoTG80nmLtgPU7rnvweej3D69aeSQETfPoq1N4u4mg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.271.0.tgz",
-      "integrity": "sha512-jCxbt6sehnmV6we2uu0rY5McREJQ9WGQ3HCtjG1qSxm1vJkROX40IUvq7uvwPi3FquqIv2pCc64vLuDdhfs6OA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.271.0.tgz",
-      "integrity": "sha512-ojbvxVdJRzvHx1SiXTX8z5qtsX/86+puqqmhTNQTed0/sp856rJVHrE+59qrOa8tNX+dHih5nzmjZ2OvhP+duA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.271.0.tgz",
-      "integrity": "sha512-VnoY5DfdkSorT/bM91FPwHduzkRFBTi/MyU/J08xPkuAQfu2CmvIBr8W15XN1ysAZbZVyDir7NeE9MNG6Q/soA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.271.0.tgz",
-      "integrity": "sha512-PbEQ7GRO9/oXXrxIMPkOsL1lKzi3FzMizFj1tLjSkN+lvUaRt2w9Yrb+P3G7Wr2VyniI8QwpAPnebQ+5Rg7yig==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.271.0.tgz",
-      "integrity": "sha512-r/wLPLUo3HeWHumvnYxP4LvMz1cKpVO7XVognt5caeDakS2CDiFN3NiCO2PFxOGoWCyMDKcroKtIdXETcgrEbQ==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/querystring-builder": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/property-provider": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.271.0.tgz",
-      "integrity": "sha512-y95eWGs2tbCESZZVqNWbDXOL43y18bZSS0mfac2n7srOfeuVh+4+8Zdhsnz/NW3Ao61+k1IxKCFnX0iKfJSu2Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.271.0.tgz",
-      "integrity": "sha512-WWyS/M+A0NoEBBLbgO1qG7oxEGWvhjsFJgX0Yzz38mKIjW8G/31X9ylaCQoGFSOTn6GXBRqc/i0P86os+wL45Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.271.0.tgz",
-      "integrity": "sha512-2FKaoeOgCyn2eShq4hZrEBQ9euHYMvh0aFwWrjQgXjUWJmV4Q+/+eob/sEDeeYvkMW45T5aIG7D+hbVowgWZAQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.271.0.tgz",
-      "integrity": "sha512-SGcxf+gaSMMST806zQxETEoe3ENWkncQh+cpDNDRo/oS582PMd7tIOAxP9JJdLJGp9UkIdSkTLWXDjzk9Zt02w==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.271.0.tgz",
-      "integrity": "sha512-yTnxoeCa4uMRfpaaq6oG1h1a01vXQ2al+D0DyX+D5sw7u6RyZOaxxUEbyfEPTN+JtRw+M+zcdlvto3swIwRqoQ==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.271.0.tgz",
-      "integrity": "sha512-PR1Hco+r1sH7WlqxaO3Vvl6a8I5juvwVjwjjorbI3EVsxQgEcyCjy1ZVnpCAxY1Xam7ne5nAWO6Y6LtfY4JJ5g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.271.0.tgz",
-      "integrity": "sha512-OzS+h0MGqzukJSrPqVi08pWDGZkq8U/yXf2LfCkQz58Rv/pbCuDIIN7Oab6IwnVPQV7KoCsegYL3e6BpOp1qpA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.271.0.tgz",
-      "integrity": "sha512-8wqNArFoLx2hy2kT5jV7JsaZ4jIqI535K1WXBCkzVLKNMv6RVYCBN57I5+C5sgVtHCZwy9RLzRHJIGLEIKIfBg==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.271.0.tgz",
-      "integrity": "sha512-tCh3Pw7VuSGT6yg8n7IeNc25IT8cjPS9Q0YKzjN8rPBZW5iI8/kJyZ7kQBj52JD8WrEYCoxG4hnDvawe1e1lAA==",
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.271.0.tgz",
-      "integrity": "sha512-w4oNKEaBul7eh2IM97c89xaH9Ti8+e+u/Rc1ZkgNtpnfOpDUU2t3ugJ91ihGH+xtASQCWJTopTDfX5CuKsQQtQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/url-parser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.271.0.tgz",
-      "integrity": "sha512-HuL38pnLaZX4zjlsm9sZfyiPvEK9gFl9viX7wpBJcF50+KgRcj1rasYCy8AfWlCEtL7A214xEutFwGqLfTyDag==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.271.0.tgz",
-      "integrity": "sha512-zyCIT/4PKiBxblZLKcMTNCllKcPhLuE08lIv1fGaqgIZzULFaAGjd/lpTO1q7I2hOt5oFL/4uzTFDrG8g5HJAg==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.271.0.tgz",
-      "integrity": "sha512-QqruC9fkrraoWxrzG7EFX/pOkoLblV2YPsvPHR37DzKSssnsQxOPbiAF95Qw2zocsDrpDuxJEe2RM800vunIsw==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/credential-provider-imds": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.271.0.tgz",
-      "integrity": "sha512-qr+IWZB0Th+TcarjTW5ZakkbKxBNKlLsnFiw3j+gECDA5raUEyTB3w6tRH0nhPFNzN6cM5P8arKlpm3R7f002Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.271.0.tgz",
-      "integrity": "sha512-qE+t+JKygIPtXvik1Dy9B2dQx8pJ5NFPms/uFi9kOexCJy8mWd4FApK+sCwT5TGWte+tY2Fg7fcTs5g7ufcsKw==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-retry": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.271.0.tgz",
-      "integrity": "sha512-tO3nHBtAlBSppM37AJNc/rUwLNypPvkDC7av2cyuCDTaH4OHLd/RqZUtvMtSXJKjxR4v8RiyiQvRVE65u0Ermw==",
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.271.0.tgz",
-      "integrity": "sha512-nFU4flPzzkG6c46ZKroXtQc6D8g/8ei3nUYJF2Poc+3UD/GiuKASWR+ymALN7Zc2YfR95LcVCNdcm1rDI1WLXA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.271.0.tgz",
-      "integrity": "sha512-okLJbQ1iBmAH+OdqDd6AmINUAQdLnhi+D9rvp4ZoE5DIhgbzFIuUK6SByB7Rl/9XE76wzkHfRhZJYPyD1cPkQA==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.271.0.tgz",
-      "integrity": "sha512-WNtUjOa9ufKK4+o58YHosjU9J8v494Fb10tHFqD4OspFWLxBKzSJ+r6xpQRcVPucxsmocGJ2QhIiNYo8OySKkA==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.271.0.tgz",
-      "integrity": "sha512-OzS+h0MGqzukJSrPqVi08pWDGZkq8U/yXf2LfCkQz58Rv/pbCuDIIN7Oab6IwnVPQV7KoCsegYL3e6BpOp1qpA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/types": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.271.0.tgz",
-      "integrity": "sha512-w4oNKEaBul7eh2IM97c89xaH9Ti8+e+u/Rc1ZkgNtpnfOpDUU2t3ugJ91ihGH+xtASQCWJTopTDfX5CuKsQQtQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.271.0.tgz",
-      "integrity": "sha512-qE+t+JKygIPtXvik1Dy9B2dQx8pJ5NFPms/uFi9kOexCJy8mWd4FApK+sCwT5TGWte+tY2Fg7fcTs5g7ufcsKw==",
-      "dependencies": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-node": "3.370.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-sdk-sts": "3.370.0",
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.271.0.tgz",
-      "integrity": "sha512-lKZGcDYe8us2Ep7/AjhLyMMTq0NuVt+M+L1eedBGRuGkx/Hrvn4qwlIvSXZhiodoQVa+Wr1zIah3Z06U0dTaZA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.370.0.tgz",
+      "integrity": "sha512-raR3yP/4GGbKFRPP5hUBNkEmTnzxI9mEc2vJAJrcv4G4J4i/UP6ELiLInQ5eO2/VcV/CeKGZA3t7d1tsJ+jhCg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.271.0.tgz",
-      "integrity": "sha512-u3KsjtGBo1SA9HQAVxfA7zHWirlrdKsqsMpnp4eOtixZLoz1e2EytrR5XZem2HND0lzjrUrEPGDPp5OpDtcHxw==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.271.0.tgz",
-      "integrity": "sha512-zIclMwXbJeNev74+0tbxLpEO2Js7AhqvR2Msiytz05kOXRyk61NMEavtKRp1YxD2KMptONnvNlbWbNW2rrRDnw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.370.0.tgz",
+      "integrity": "sha512-eJyapFKa4NrC9RfTgxlXnXfS9InG/QMEUPPVL+VhG7YS6nKqetC1digOYgivnEeu+XSKE0DJ7uZuXujN2Y7VAQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.271.0",
-        "@aws-sdk/credential-provider-imds": "3.271.0",
-        "@aws-sdk/credential-provider-process": "3.271.0",
-        "@aws-sdk/credential-provider-sso": "3.271.0",
-        "@aws-sdk/credential-provider-web-identity": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.370.0",
+        "@aws-sdk/credential-provider-process": "3.370.0",
+        "@aws-sdk/credential-provider-sso": "3.370.0",
+        "@aws-sdk/credential-provider-web-identity": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.271.0.tgz",
-      "integrity": "sha512-hfdJ+8QM5xXEm4mF4AfIy6T1fVb2zTaUVm5PfPDHtkggVM1L+QSywEkZ2lUqQZMLbbatJqVLy2EMA91k5kjVrA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.370.0.tgz",
+      "integrity": "sha512-gkFiotBFKE4Fcn8CzQnMeab9TAR06FEAD02T4ZRYW1xGrBJOowmje9dKqdwQFHSPgnWAP+8HoTA8iwbhTLvjNA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.271.0",
-        "@aws-sdk/credential-provider-imds": "3.271.0",
-        "@aws-sdk/credential-provider-ini": "3.271.0",
-        "@aws-sdk/credential-provider-process": "3.271.0",
-        "@aws-sdk/credential-provider-sso": "3.271.0",
-        "@aws-sdk/credential-provider-web-identity": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.370.0",
+        "@aws-sdk/credential-provider-ini": "3.370.0",
+        "@aws-sdk/credential-provider-process": "3.370.0",
+        "@aws-sdk/credential-provider-sso": "3.370.0",
+        "@aws-sdk/credential-provider-web-identity": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.271.0.tgz",
-      "integrity": "sha512-Q1HIZYTUYLVe0cNc3HbtFOFzgo3A6PHcmT62T8XClAhFRhkOsJ/KWUybjm8col49/1uqIjKA20E7P7f5Qnn2TQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.370.0.tgz",
+      "integrity": "sha512-0BKFFZmUO779Xdw3u7wWnoWhYA4zygxJbgGVSyjkOGBvdkbPSTTcdwT1KFkaQy2kOXYeZPl+usVVRXs+ph4ejg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.271.0.tgz",
-      "integrity": "sha512-TIvsv4xXTME6UsH7g05IzVDCLujaMmgv45A0KcAyM/J/HvFQ9IBOBdyKGU5zIawPvCWXiqQqZs/kDchdB2sjXA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.370.0.tgz",
+      "integrity": "sha512-PFroYm5hcPSfC/jkZnCI34QFL3I7WVKveVk6/F3fud/cnP8hp6YjA9NiTNbqdFSzsyoiN/+e5fZgNKih8vVPTA==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/token-providers": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.370.0",
+        "@aws-sdk/token-providers": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.271.0.tgz",
-      "integrity": "sha512-GD1mg7fMA3ESl0jdzH/+keZHV9Fue/iaGMIWNCUm7M9dOJo0JZbDNzSaMtxZnuA6xtkvw3FiLH6ZxPt0V+7wmg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.370.0.tgz",
+      "integrity": "sha512-CFaBMLRudwhjv1sDzybNV93IaT85IwS+L8Wq6VRMa0mro1q9rrWsIZO811eF+k0NEPfgU1dLH+8Vc2qhw4SARQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.271.0.tgz",
-      "integrity": "sha512-yc0YgKioACFcfs7RPtVHRlpsyYJNdEHkqiWtnRSXG0vuZHAkfvwzchrDK4bizMblnmEV/xbl495ZqDlVbQ0c9A==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/querystring-builder": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.271.0.tgz",
-      "integrity": "sha512-VamRhkGo2uaVe7KhQhdTqpp9y5JKSFNE3yCUZf/o6lGwL9BgBpBiVqzwCePtas7hAphAaOYvefIwx0XLaCeQ1w==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.271.0.tgz",
-      "integrity": "sha512-ZN8JmN/t+4UTHkQ6wdod2KKLfJcewLS3D/0iZLnvvOzLlymhcHp9QY8t//RObF+WxnlWeCAvZttoMl/a2MLpYQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/md5-js": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.271.0.tgz",
-      "integrity": "sha512-WzgLeDxWg8d8jARXhVc2M/+PyolkTyR0VWoIqdAPnQdLAHisUq3NxM1Ufp9e6Z4SIFW3ovtG84GHFBxSeFp/cw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.271.0.tgz",
-      "integrity": "sha512-bmfqCvjFcowa6jLltJIkGHNXY599Fu9ROoMtYjQiD2ixWHmUpS0I/VivcxXL3uES2qhehxYXyJFyCt7aqRQqcA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.271.0.tgz",
-      "integrity": "sha512-pibhIe57e68NAfDUY5c7d9zo6WfNwgfclwtrK0nV3OXw9psNeCLGLC1YbzsTun49tm0ICSmkHgmqfsXAVe4HWA==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.271.0.tgz",
-      "integrity": "sha512-sp75WZDzDui/Wr3GnQH/db4DXgVdOpKdRQddDsRuULzri8HeJlhMW+JCP+sP0kQmkO06Dagxv1tSmENUxFhPaQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.370.0.tgz",
+      "integrity": "sha512-CPXOm/TnOFC7KyXcJglICC7OiA7Kj6mT3ChvEijr56TFOueNHvJdV4aNIFEQy0vGHOWtY12qOWLNto/wYR1BAQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.271.0.tgz",
-      "integrity": "sha512-mB/vayfsuc20PySSpbbQ56CPER/RAZF5oGkwGuwFI3bY+VwRun0MOnx3yHj7Ja2DN1ZEOH1Hzrb0eUgREozmHw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.370.0.tgz",
+      "integrity": "sha512-cQMq9SaZ/ORmTJPCT6VzMML7OxFdQzNkhMAgKpTDl+tdPWynlHF29E5xGoSzROnThHlQPCjogU0NZ8AxI0SWPA==",
       "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.271.0.tgz",
-      "integrity": "sha512-prrS/YL3GdLODqVBSgxvpUfo9aPBLB3Km5wNBdbhjjN0rI1RqjD+0LquVgaz6C1VU/I8cYbnxrFYtQVcdgnWpg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.370.0.tgz",
+      "integrity": "sha512-L7ZF/w0lAAY/GK1khT8VdoU0XB7nWHk51rl/ecAg64J70dHnMOAg8n+5FZ9fBu/xH1FwUlHOkwlodJOgzLJjtg==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.271.0.tgz",
-      "integrity": "sha512-yCBXmxbFGT/4czTi+e4z7lV0nbMWctvvzOtl1ssBiG0LagijIhK4KUp0KTnqDJ+yBqxMpd7wNJ1B0NdS0re6Fw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/service-error-classification": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.271.0.tgz",
-      "integrity": "sha512-9R25mEaxcTrF/YI4m4drMYvLFvEEyCCrQEpls3WXGUbeRcwOGAhLqKmdwKf/bMkG1SDMx+OLrzzmk9DLa7J83g==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.370.0.tgz",
+      "integrity": "sha512-jk61LjuxYe3gfcxuPsAPuKCycTGC7bhd8VHGBjlndLmYIG6Y6t668fvVXTKsz+CWQLTpAjhkS8ON2nJKiMqaQw==",
       "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.271.0.tgz",
-      "integrity": "sha512-/h8+PAx+85M+tSL/kl1lWVgHrrodmDRuQuDLXC7ufE6C1JRxRBkWMTOg6S3ZeuKo1Va/8RcAKf7jtkGdIBD5HQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.370.0.tgz",
+      "integrity": "sha512-ykbsoVy0AJtVbuhAlTAMcaz/tCE3pT8nAp0L7CQQxSoanRCvOux7au0KwMIQVhxgnYid4dWVF6d00SkqU5MXRA==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.271.0.tgz",
-      "integrity": "sha512-jCxbt6sehnmV6we2uu0rY5McREJQ9WGQ3HCtjG1qSxm1vJkROX40IUvq7uvwPi3FquqIv2pCc64vLuDdhfs6OA==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/property-provider": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.271.0.tgz",
-      "integrity": "sha512-y95eWGs2tbCESZZVqNWbDXOL43y18bZSS0mfac2n7srOfeuVh+4+8Zdhsnz/NW3Ao61+k1IxKCFnX0iKfJSu2Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.271.0.tgz",
-      "integrity": "sha512-WWyS/M+A0NoEBBLbgO1qG7oxEGWvhjsFJgX0Yzz38mKIjW8G/31X9ylaCQoGFSOTn6GXBRqc/i0P86os+wL45Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.271.0.tgz",
-      "integrity": "sha512-OzS+h0MGqzukJSrPqVi08pWDGZkq8U/yXf2LfCkQz58Rv/pbCuDIIN7Oab6IwnVPQV7KoCsegYL3e6BpOp1qpA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/types": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.271.0.tgz",
-      "integrity": "sha512-w4oNKEaBul7eh2IM97c89xaH9Ti8+e+u/Rc1ZkgNtpnfOpDUU2t3ugJ91ihGH+xtASQCWJTopTDfX5CuKsQQtQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.271.0.tgz",
-      "integrity": "sha512-qE+t+JKygIPtXvik1Dy9B2dQx8pJ5NFPms/uFi9kOexCJy8mWd4FApK+sCwT5TGWte+tY2Fg7fcTs5g7ufcsKw==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.271.0.tgz",
-      "integrity": "sha512-louPEKEZP2TtTavMwg4k6IJjEbXC6xV05Wtb4I+ZKzjupoTG80nmLtgPU7rnvweej3D69aeSQETfPoq1N4u4mg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.271.0.tgz",
-      "integrity": "sha512-jCxbt6sehnmV6we2uu0rY5McREJQ9WGQ3HCtjG1qSxm1vJkROX40IUvq7uvwPi3FquqIv2pCc64vLuDdhfs6OA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.370.0.tgz",
+      "integrity": "sha512-Dwr/RTCWOXdm394wCwICGT2VNOTMRe4IGPsBRJAsM24pm+EEqQzSS3Xu/U/zF4exuxqpMta4wec4QpSarPNTxA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.271.0.tgz",
-      "integrity": "sha512-ojbvxVdJRzvHx1SiXTX8z5qtsX/86+puqqmhTNQTed0/sp856rJVHrE+59qrOa8tNX+dHih5nzmjZ2OvhP+duA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/signature-v4": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.271.0.tgz",
-      "integrity": "sha512-VnoY5DfdkSorT/bM91FPwHduzkRFBTi/MyU/J08xPkuAQfu2CmvIBr8W15XN1ysAZbZVyDir7NeE9MNG6Q/soA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.370.0.tgz",
+      "integrity": "sha512-2+3SB6MtMAq1+gVXhw0Y3ONXuljorh6ijnxgTpv+uQnBW5jHCUiAS8WDYiDEm7i9euJPbvJfM8WUrSMDMU6Cog==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.271.0.tgz",
-      "integrity": "sha512-PbEQ7GRO9/oXXrxIMPkOsL1lKzi3FzMizFj1tLjSkN+lvUaRt2w9Yrb+P3G7Wr2VyniI8QwpAPnebQ+5Rg7yig==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.271.0.tgz",
-      "integrity": "sha512-r/wLPLUo3HeWHumvnYxP4LvMz1cKpVO7XVognt5caeDakS2CDiFN3NiCO2PFxOGoWCyMDKcroKtIdXETcgrEbQ==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/querystring-builder": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.271.0.tgz",
-      "integrity": "sha512-y95eWGs2tbCESZZVqNWbDXOL43y18bZSS0mfac2n7srOfeuVh+4+8Zdhsnz/NW3Ao61+k1IxKCFnX0iKfJSu2Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.271.0.tgz",
-      "integrity": "sha512-WWyS/M+A0NoEBBLbgO1qG7oxEGWvhjsFJgX0Yzz38mKIjW8G/31X9ylaCQoGFSOTn6GXBRqc/i0P86os+wL45Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.271.0.tgz",
-      "integrity": "sha512-2FKaoeOgCyn2eShq4hZrEBQ9euHYMvh0aFwWrjQgXjUWJmV4Q+/+eob/sEDeeYvkMW45T5aIG7D+hbVowgWZAQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.271.0.tgz",
-      "integrity": "sha512-SGcxf+gaSMMST806zQxETEoe3ENWkncQh+cpDNDRo/oS582PMd7tIOAxP9JJdLJGp9UkIdSkTLWXDjzk9Zt02w==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.271.0.tgz",
-      "integrity": "sha512-yTnxoeCa4uMRfpaaq6oG1h1a01vXQ2al+D0DyX+D5sw7u6RyZOaxxUEbyfEPTN+JtRw+M+zcdlvto3swIwRqoQ==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.271.0.tgz",
-      "integrity": "sha512-PR1Hco+r1sH7WlqxaO3Vvl6a8I5juvwVjwjjorbI3EVsxQgEcyCjy1ZVnpCAxY1Xam7ne5nAWO6Y6LtfY4JJ5g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.271.0.tgz",
-      "integrity": "sha512-OzS+h0MGqzukJSrPqVi08pWDGZkq8U/yXf2LfCkQz58Rv/pbCuDIIN7Oab6IwnVPQV7KoCsegYL3e6BpOp1qpA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.271.0.tgz",
-      "integrity": "sha512-8wqNArFoLx2hy2kT5jV7JsaZ4jIqI535K1WXBCkzVLKNMv6RVYCBN57I5+C5sgVtHCZwy9RLzRHJIGLEIKIfBg==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.271.0.tgz",
-      "integrity": "sha512-tCh3Pw7VuSGT6yg8n7IeNc25IT8cjPS9Q0YKzjN8rPBZW5iI8/kJyZ7kQBj52JD8WrEYCoxG4hnDvawe1e1lAA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.370.0.tgz",
+      "integrity": "sha512-EyR2ZYr+lJeRiZU2/eLR+mlYU9RXLQvNyGFSAekJKgN13Rpq/h0syzXVFLP/RSod/oZenh/fhVZ2HwlZxuGBtQ==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso-oidc": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.271.0.tgz",
-      "integrity": "sha512-w4oNKEaBul7eh2IM97c89xaH9Ti8+e+u/Rc1ZkgNtpnfOpDUU2t3ugJ91ihGH+xtASQCWJTopTDfX5CuKsQQtQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
+      "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.271.0.tgz",
-      "integrity": "sha512-HuL38pnLaZX4zjlsm9sZfyiPvEK9gFl9viX7wpBJcF50+KgRcj1rasYCy8AfWlCEtL7A214xEutFwGqLfTyDag==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.271.0.tgz",
-      "integrity": "sha512-zyCIT/4PKiBxblZLKcMTNCllKcPhLuE08lIv1fGaqgIZzULFaAGjd/lpTO1q7I2hOt5oFL/4uzTFDrG8g5HJAg==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.271.0.tgz",
-      "integrity": "sha512-QqruC9fkrraoWxrzG7EFX/pOkoLblV2YPsvPHR37DzKSssnsQxOPbiAF95Qw2zocsDrpDuxJEe2RM800vunIsw==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/credential-provider-imds": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.271.0.tgz",
-      "integrity": "sha512-qr+IWZB0Th+TcarjTW5ZakkbKxBNKlLsnFiw3j+gECDA5raUEyTB3w6tRH0nhPFNzN6cM5P8arKlpm3R7f002Q==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.370.0.tgz",
+      "integrity": "sha512-5ltVAnM79nRlywwzZN5i8Jp4tk245OCGkKwwXbnDU+gq7zT3CIOsct1wNZvmpfZEPGt/bv7/NyRcjP+7XNsX/g==",
       "dependencies": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2782,58 +1502,26 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.271.0.tgz",
-      "integrity": "sha512-qE+t+JKygIPtXvik1Dy9B2dQx8pJ5NFPms/uFi9kOexCJy8mWd4FApK+sCwT5TGWte+tY2Fg7fcTs5g7ufcsKw==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-retry": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.271.0.tgz",
-      "integrity": "sha512-tO3nHBtAlBSppM37AJNc/rUwLNypPvkDC7av2cyuCDTaH4OHLd/RqZUtvMtSXJKjxR4v8RiyiQvRVE65u0Ermw==",
-      "dependencies": {
-        "@aws-sdk/service-error-classification": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.271.0.tgz",
-      "integrity": "sha512-nFU4flPzzkG6c46ZKroXtQc6D8g/8ei3nUYJF2Poc+3UD/GiuKASWR+ymALN7Zc2YfR95LcVCNdcm1rDI1WLXA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.370.0.tgz",
+      "integrity": "sha512-028LxYZMQ0DANKhW+AKFQslkScZUeYlPmSphrCIXgdIItRZh6ZJHGzE7J/jDsEntZOrZJsjI4z0zZ5W2idj04w==",
       "dependencies": {
-        "@aws-sdk/types": "3.271.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.271.0.tgz",
-      "integrity": "sha512-okLJbQ1iBmAH+OdqDd6AmINUAQdLnhi+D9rvp4ZoE5DIhgbzFIuUK6SByB7Rl/9XE76wzkHfRhZJYPyD1cPkQA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.370.0.tgz",
+      "integrity": "sha512-33vxZUp8vxTT/DGYIR3PivQm07sSRGWI+4fCv63Rt7Q++fO24E0kQtmVAlikRY810I10poD6rwILVtITtFSzkg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2845,18 +1533,6 @@
         "aws-crt": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.254.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
-      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
@@ -2871,7 +1547,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.2.tgz",
       "integrity": "sha512-tb2h0b+JvMee+eAxTmhnyqyNk51UXIK949HnE14lFeezKsVJTB30maan+CO2IMwnig2wVYQH84B5qk6ylmKCuA==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -2884,7 +1559,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.2.tgz",
       "integrity": "sha512-8Bk7CgnVKg1dn5TgnjwPz2ebhxeR7CjGs5yhVYH3S8x0q8yPZZVWwpRIglwXaf5AZBzJlNO1lh+lUhMf2e73zQ==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-config-provider": "^1.0.2",
@@ -2899,7 +1573,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.2.tgz",
       "integrity": "sha512-fLjCya+JOu2gPJpCiwSUyoLvT8JdNJmOaTOkKYBZoGf7CzqR6lluSyI+eboZnl/V0xqcfcqBG4tgqCISmWS3/w==",
-      "peer": true,
       "dependencies": {
         "@smithy/node-config-provider": "^1.0.2",
         "@smithy/property-provider": "^1.0.2",
@@ -2915,7 +1588,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.2.tgz",
       "integrity": "sha512-eW/XPiLauR1VAgHKxhVvgvHzLROUgTtqat2lgljztbH8uIYWugv7Nz+SgCavB+hWRazv2iYgqrSy74GvxXq/rg==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^1.1.1",
@@ -2982,7 +1654,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.2.tgz",
       "integrity": "sha512-kynyofLf62LvR8yYphPPdyHb8fWG3LepFinM/vWUTG2Q1pVpmPCM530ppagp3+q2p+7Ox0UvSqldbKqV/d1BpA==",
-      "peer": true,
       "dependencies": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/querystring-builder": "^1.0.2",
@@ -2995,7 +1666,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.2.tgz",
       "integrity": "sha512-K6PKhcUNrJXtcesyzhIvNlU7drfIU7u+EMQuGmPw6RQDAg/ufUcfKHz4EcUhFAodUmN+rrejhRG9U6wxjeBOQA==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-buffer-from": "^1.0.2",
@@ -3010,17 +1680,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.2.tgz",
       "integrity": "sha512-B1Y3Tsa6dfC+Vvb+BJMhTHOfFieeYzY9jWQSTR1vMwKkxsymD0OIAnEw8rD/RiDj/4E4RPGFdx9Mdgnyd6Bv5Q==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-pkyBnsBRpe+c/6ASavqIMRBdRtZNJEVJOEzhpxZ9JoAXiZYbkfaSMRA/O1dUxGdJ653GHONunnZ4xMo/LJ7utQ==",
-      "peer": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz",
+      "integrity": "sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3028,11 +1696,20 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/md5-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-1.1.0.tgz",
+      "integrity": "sha512-ftB+GrB/AgF+NlaoVMc3wlXZxsAcenrq2inrc6FfwM2tXUmU2Oc1W3qVW7rIDNqR6GmvXkAIxlnp6P2QkwlkNw==",
+      "dependencies": {
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-utf8": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
     "node_modules/@smithy/middleware-content-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.2.tgz",
       "integrity": "sha512-pa1/SgGIrSmnEr2c9Apw7CdU4l/HW0fK3+LKFCPDYJrzM0JdYpqjQzgxi31P00eAkL0EFBccpus/p1n2GF9urw==",
-      "peer": true,
       "dependencies": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/types": "^1.1.1",
@@ -3046,7 +1723,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz",
       "integrity": "sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==",
-      "peer": true,
       "dependencies": {
         "@smithy/middleware-serde": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -3062,7 +1738,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz",
       "integrity": "sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==",
-      "peer": true,
       "dependencies": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/service-error-classification": "^1.0.3",
@@ -3080,7 +1755,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -3089,7 +1763,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz",
       "integrity": "sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -3102,7 +1775,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.2.tgz",
       "integrity": "sha512-H7/uAQEcmO+eDqweEFMJ5YrIpsBwmrXSP6HIIbtxKJSQpAcMGY7KrR2FZgZBi1FMnSUOh+rQrbOyj5HQmSeUBA==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3114,7 +1786,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.2.tgz",
       "integrity": "sha512-HU7afWpTToU0wL6KseGDR2zojeyjECQfr8LpjAIeHCYIW7r360ABFf4EaplaJRMVoC3hD9FeltgI3/NtShOqCg==",
-      "peer": true,
       "dependencies": {
         "@smithy/property-provider": "^1.0.2",
         "@smithy/shared-ini-file-loader": "^1.0.2",
@@ -3129,7 +1800,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.3.tgz",
       "integrity": "sha512-PcPUSzTbIb60VCJCiH0PU0E6bwIekttsIEf5Aoo/M0oTfiqsxHTn0Rcij6QoH6qJy6piGKXzLSegspXg5+Kq6g==",
-      "peer": true,
       "dependencies": {
         "@smithy/abort-controller": "^1.0.2",
         "@smithy/protocol-http": "^1.1.1",
@@ -3145,7 +1815,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.2.tgz",
       "integrity": "sha512-pXDPyzKX8opzt38B205kDgaxda6LHcTfPvTYQZnwP6BAPp1o9puiCPjeUtkKck7Z6IbpXCPUmUQnzkUzWTA42Q==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -3158,7 +1827,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
       "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -3171,7 +1839,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.2.tgz",
       "integrity": "sha512-6P/xANWrtJhMzTPUR87AbXwSBuz1SDHIfL44TFd/GT3hj6rA+IEv7rftEpPjayUiWRocaNnrCPLvmP31mobOyA==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-uri-escape": "^1.0.2",
@@ -3185,7 +1852,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz",
       "integrity": "sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -3198,7 +1864,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz",
       "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA==",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3207,7 +1872,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.2.tgz",
       "integrity": "sha512-bdQj95VN+lCXki+P3EsDyrkpeLn8xDYiOISBGnUG/AGPYJXN8dmp4EhRRR7XOoLoSs8anZHR4UcGEOzFv2jwGw==",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -3220,7 +1884,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.2.tgz",
       "integrity": "sha512-rpKUhmCuPmpV5dloUkOb9w1oBnJatvKQEjIHGmkjRGZnC3437MTdzWej9TxkagcZ8NRRJavYnEUixzxM1amFig==",
-      "peer": true,
       "dependencies": {
         "@smithy/eventstream-codec": "^1.0.2",
         "@smithy/is-array-buffer": "^1.0.2",
@@ -3239,7 +1902,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.4.tgz",
       "integrity": "sha512-gpo0Xl5Nyp9sgymEfpt7oa9P2q/GlM3VmQIdm+FeH0QEdYOQx3OtvwVmBYAMv2FIPWxkMZlsPYRTnEiBTK5TYg==",
-      "peer": true,
       "dependencies": {
         "@smithy/middleware-stack": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -3251,10 +1913,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
-      "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
-      "peer": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3266,7 +1927,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.2.tgz",
       "integrity": "sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==",
-      "peer": true,
       "dependencies": {
         "@smithy/querystring-parser": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -3277,7 +1937,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.2.tgz",
       "integrity": "sha512-BCm15WILJ3SL93nusoxvJGMVfAMWHZhdeDZPtpAaskozuexd0eF6szdz4kbXaKp38bFCSenA6bkUHqaE3KK0dA==",
-      "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^1.0.2",
         "tslib": "^2.5.0"
@@ -3290,7 +1949,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.2.tgz",
       "integrity": "sha512-Xh8L06H2anF5BHjSYTg8hx+Itcbf4SQZnVMl4PIkCOsKtneMJoGjPRLy17lEzfoh/GOaa0QxgCP6lRMQWzNl4w==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       }
@@ -3299,7 +1957,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.2.tgz",
       "integrity": "sha512-nXHbZsUtvZeyfL4Ceds9nmy2Uh2AhWXohG4vWHyjSdmT8cXZlJdmJgnH6SJKDjyUecbu+BpKeVvSrA4cWPSOPA==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3308,12 +1965,11 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.2.tgz",
-      "integrity": "sha512-lHAYIyrBO9RANrPvccnPjU03MJnWZ66wWuC5GjWWQVfsmPwU6m00aakZkzHdUT6tGCkGacXSgArP5wgTgA+oCw==",
-      "peer": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz",
+      "integrity": "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^1.0.2",
+        "@smithy/is-array-buffer": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3324,7 +1980,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.2.tgz",
       "integrity": "sha512-HOdmDm+3HUbuYPBABLLHtn8ittuRyy+BSjKOA169H+EMc+IozipvXDydf+gKBRAxUa4dtKQkLraypwppzi+PRw==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3336,7 +1991,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.2.tgz",
       "integrity": "sha512-J1u2PO235zxY7dg0+ZqaG96tFg4ehJZ7isGK1pCBEA072qxNPwIpDzUVGnLJkHZvjWEGA8rxIauDtXfB0qxeAg==",
-      "peer": true,
       "dependencies": {
         "@smithy/property-provider": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -3351,7 +2005,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.2.tgz",
       "integrity": "sha512-9/BN63rlIsFStvI+AvljMh873Xw6bbI6b19b+PVYXyycQ2DDQImWcjnzRlHW7eP65CCUNGQ6otDLNdBQCgMXqg==",
-      "peer": true,
       "dependencies": {
         "@smithy/config-resolver": "^1.0.2",
         "@smithy/credential-provider-imds": "^1.0.2",
@@ -3368,7 +2021,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.2.tgz",
       "integrity": "sha512-Bxydb5rMJorMV6AuDDMOxro3BMDdIwtbQKHpwvQFASkmr52BnpDsWlxgpJi8Iq7nk1Bt4E40oE1Isy/7ubHGzg==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3380,7 +2032,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.2.tgz",
       "integrity": "sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3392,7 +2043,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.4.tgz",
       "integrity": "sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==",
-      "peer": true,
       "dependencies": {
         "@smithy/service-error-classification": "^1.0.3",
         "tslib": "^2.5.0"
@@ -3405,7 +2055,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.2.tgz",
       "integrity": "sha512-qyN2M9QFMTz4UCHi6GnBfLOGYKxQZD01Ga6nzaXFFC51HP/QmArU72e4kY50Z/EtW8binPxspP2TAsGbwy9l3A==",
-      "peer": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^1.0.2",
         "@smithy/node-http-handler": "^1.0.3",
@@ -3424,7 +2073,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.2.tgz",
       "integrity": "sha512-k8C0BFNS9HpBMHSgUDnWb1JlCQcFG+PPlVBq9keP4Nfwv6a9Q0yAfASWqUCtzjuMj1hXeLhn/5ADP6JxnID1Pg==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -3433,12 +2081,11 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.2.tgz",
-      "integrity": "sha512-V4cyjKfJlARui0dMBfWJMQAmJzoW77i4N3EjkH/bwnE2Ngbl4tqD2Y0C/xzpzY/J1BdxeCKxAebVFk8aFCaSCw==",
-      "peer": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.1.0.tgz",
+      "integrity": "sha512-p/MYV+JmqmPyjdgyN2UxAeYDj9cBqCjp0C/NsTWnnjoZUVqoeZ6IrW915L9CAKWVECgv9lVQGc4u/yz26/bI1A==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^1.0.2",
+        "@smithy/util-buffer-from": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3493,18 +2140,24 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/ms": {
@@ -3561,7 +2214,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "peer": true,
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -3571,8 +2223,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "peer": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -3660,15 +2311,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
-      }
-    },
-    "@aws-sdk/abort-controller": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.271.0.tgz",
-      "integrity": "sha512-sP4RvP0fvmMySS6hV/EKMrTJ9KVMH85rn1EKvmJ3nBTKRKiR8GQUS/vX+dhLYu+3jRs2P6cY2zjGzpaOcII91w==",
-      "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-lambda": {
@@ -4077,15 +2719,6 @@
           "requires": {
             "tslib": "^2.5.0"
           }
-        },
-        "fast-xml-parser": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-          "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-          "peer": true,
-          "requires": {
-            "strnum": "^1.0.5"
-          }
         }
       }
     },
@@ -4491,1385 +3124,372 @@
           "requires": {
             "tslib": "^2.5.0"
           }
-        },
-        "fast-xml-parser": {
-          "version": "4.2.5",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-          "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-          "peer": true,
-          "requires": {
-            "strnum": "^1.0.5"
-          }
         }
       }
     },
     "@aws-sdk/client-sqs": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.271.0.tgz",
-      "integrity": "sha512-46IsI9GI1EJgzBOSP6+/+JY5uI8MZHxJ3GE0eCnZQKD9knJw31xfExVFjGDFOYY5cfkdUz/YXUhRRPieP6sxJw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.370.0.tgz",
+      "integrity": "sha512-HaF+Jb5dKtvv2uA5WhtPMPM4d6vczHGKV1x/CRFJv2NDwHJX6E84RZ+74008SCjdA3C1RqvErrjw0iSwYyN7CA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.271.0",
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/credential-provider-node": "3.271.0",
-        "@aws-sdk/fetch-http-handler": "3.271.0",
-        "@aws-sdk/hash-node": "3.271.0",
-        "@aws-sdk/invalid-dependency": "3.271.0",
-        "@aws-sdk/md5-js": "3.271.0",
-        "@aws-sdk/middleware-content-length": "3.271.0",
-        "@aws-sdk/middleware-endpoint": "3.271.0",
-        "@aws-sdk/middleware-host-header": "3.271.0",
-        "@aws-sdk/middleware-logger": "3.271.0",
-        "@aws-sdk/middleware-recursion-detection": "3.271.0",
-        "@aws-sdk/middleware-retry": "3.271.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.271.0",
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/middleware-signing": "3.271.0",
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/middleware-user-agent": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/node-http-handler": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/smithy-client": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-        "@aws-sdk/util-defaults-mode-node": "3.271.0",
-        "@aws-sdk/util-endpoints": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "@aws-sdk/util-user-agent-browser": "3.271.0",
-        "@aws-sdk/util-user-agent-node": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sts": "3.370.0",
+        "@aws-sdk/credential-provider-node": "3.370.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.370.0",
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/md5-js": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.271.0.tgz",
-      "integrity": "sha512-auWPqok8yJ2UOQfNrvfLNmvf0tRAbekaZRvZZ2TzTKTKd7yz6V7Y5+AdRnp01FHoOQ+8A7MHTXtp7h7i9qltKw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.370.0.tgz",
+      "integrity": "sha512-0Ty1iHuzNxMQtN7nahgkZr4Wcu1XvqGfrQniiGdKKif9jG/4elxsQPiydRuQpFqN6b+bg7wPP7crFP1uTxx2KQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/fetch-http-handler": "3.271.0",
-        "@aws-sdk/hash-node": "3.271.0",
-        "@aws-sdk/invalid-dependency": "3.271.0",
-        "@aws-sdk/middleware-content-length": "3.271.0",
-        "@aws-sdk/middleware-endpoint": "3.271.0",
-        "@aws-sdk/middleware-host-header": "3.271.0",
-        "@aws-sdk/middleware-logger": "3.271.0",
-        "@aws-sdk/middleware-recursion-detection": "3.271.0",
-        "@aws-sdk/middleware-retry": "3.271.0",
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/middleware-user-agent": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/node-http-handler": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/smithy-client": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-        "@aws-sdk/util-defaults-mode-node": "3.271.0",
-        "@aws-sdk/util-endpoints": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "@aws-sdk/util-user-agent-browser": "3.271.0",
-        "@aws-sdk/util-user-agent-node": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.271.0.tgz",
-      "integrity": "sha512-pYN8r0slDbP0v2q0SyLKihE2PPfbsF/hH7+11w6OpAMvSGvfm+m8R5rB49Szy3bkDudR0MhLpD6D76yoy9ckrQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.370.0.tgz",
+      "integrity": "sha512-jAYOO74lmVXylQylqkPrjLzxvUnMKw476JCUTvCO6Q8nv3LzCWd76Ihgv/m9Q4M2Tbqi1iP2roVK5bstsXzEjA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/fetch-http-handler": "3.271.0",
-        "@aws-sdk/hash-node": "3.271.0",
-        "@aws-sdk/invalid-dependency": "3.271.0",
-        "@aws-sdk/middleware-content-length": "3.271.0",
-        "@aws-sdk/middleware-endpoint": "3.271.0",
-        "@aws-sdk/middleware-host-header": "3.271.0",
-        "@aws-sdk/middleware-logger": "3.271.0",
-        "@aws-sdk/middleware-recursion-detection": "3.271.0",
-        "@aws-sdk/middleware-retry": "3.271.0",
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/middleware-user-agent": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/node-http-handler": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/smithy-client": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-        "@aws-sdk/util-defaults-mode-node": "3.271.0",
-        "@aws-sdk/util-endpoints": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "@aws-sdk/util-user-agent-browser": "3.271.0",
-        "@aws-sdk/util-user-agent-node": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.271.0.tgz",
-      "integrity": "sha512-dsLGj1Q3EdqLYNjm0WpeK07wv8Xed6R+tCf+x4KMWOAVAnz72XuoZNWDI2NvACubAniEhpFycMmf39Y6NCAkLg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.370.0.tgz",
+      "integrity": "sha512-utFxOPWIzbN+3kc415Je2o4J72hOLNhgR2Gt5EnRSggC3yOnkC4GzauxG8n7n5gZGBX45eyubHyPOXLOIyoqQA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/credential-provider-node": "3.271.0",
-        "@aws-sdk/fetch-http-handler": "3.271.0",
-        "@aws-sdk/hash-node": "3.271.0",
-        "@aws-sdk/invalid-dependency": "3.271.0",
-        "@aws-sdk/middleware-content-length": "3.271.0",
-        "@aws-sdk/middleware-endpoint": "3.271.0",
-        "@aws-sdk/middleware-host-header": "3.271.0",
-        "@aws-sdk/middleware-logger": "3.271.0",
-        "@aws-sdk/middleware-recursion-detection": "3.271.0",
-        "@aws-sdk/middleware-retry": "3.271.0",
-        "@aws-sdk/middleware-sdk-sts": "3.271.0",
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/middleware-signing": "3.271.0",
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/middleware-user-agent": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/node-http-handler": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/smithy-client": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-        "@aws-sdk/util-defaults-mode-node": "3.271.0",
-        "@aws-sdk/util-endpoints": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "@aws-sdk/util-user-agent-browser": "3.271.0",
-        "@aws-sdk/util-user-agent-node": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-crypto/ie11-detection": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-browser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-          "requires": {
-            "@aws-crypto/ie11-detection": "^3.0.0",
-            "@aws-crypto/sha256-js": "^3.0.0",
-            "@aws-crypto/supports-web-crypto": "^3.0.0",
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-          "requires": {
-            "@aws-crypto/util": "^3.0.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-          "requires": {
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-utf8-browser": "^3.0.0",
-            "tslib": "^1.11.1"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "@aws-sdk/abort-controller": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.271.0.tgz",
-          "integrity": "sha512-sP4RvP0fvmMySS6hV/EKMrTJ9KVMH85rn1EKvmJ3nBTKRKiR8GQUS/vX+dhLYu+3jRs2P6cY2zjGzpaOcII91w==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.271.0.tgz",
-          "integrity": "sha512-auWPqok8yJ2UOQfNrvfLNmvf0tRAbekaZRvZZ2TzTKTKd7yz6V7Y5+AdRnp01FHoOQ+8A7MHTXtp7h7i9qltKw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.271.0",
-            "@aws-sdk/fetch-http-handler": "3.271.0",
-            "@aws-sdk/hash-node": "3.271.0",
-            "@aws-sdk/invalid-dependency": "3.271.0",
-            "@aws-sdk/middleware-content-length": "3.271.0",
-            "@aws-sdk/middleware-endpoint": "3.271.0",
-            "@aws-sdk/middleware-host-header": "3.271.0",
-            "@aws-sdk/middleware-logger": "3.271.0",
-            "@aws-sdk/middleware-recursion-detection": "3.271.0",
-            "@aws-sdk/middleware-retry": "3.271.0",
-            "@aws-sdk/middleware-serde": "3.271.0",
-            "@aws-sdk/middleware-stack": "3.271.0",
-            "@aws-sdk/middleware-user-agent": "3.271.0",
-            "@aws-sdk/node-config-provider": "3.271.0",
-            "@aws-sdk/node-http-handler": "3.271.0",
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/smithy-client": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/url-parser": "3.271.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-            "@aws-sdk/util-defaults-mode-node": "3.271.0",
-            "@aws-sdk/util-endpoints": "3.271.0",
-            "@aws-sdk/util-retry": "3.271.0",
-            "@aws-sdk/util-user-agent-browser": "3.271.0",
-            "@aws-sdk/util-user-agent-node": "3.271.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.271.0.tgz",
-          "integrity": "sha512-pYN8r0slDbP0v2q0SyLKihE2PPfbsF/hH7+11w6OpAMvSGvfm+m8R5rB49Szy3bkDudR0MhLpD6D76yoy9ckrQ==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.271.0",
-            "@aws-sdk/fetch-http-handler": "3.271.0",
-            "@aws-sdk/hash-node": "3.271.0",
-            "@aws-sdk/invalid-dependency": "3.271.0",
-            "@aws-sdk/middleware-content-length": "3.271.0",
-            "@aws-sdk/middleware-endpoint": "3.271.0",
-            "@aws-sdk/middleware-host-header": "3.271.0",
-            "@aws-sdk/middleware-logger": "3.271.0",
-            "@aws-sdk/middleware-recursion-detection": "3.271.0",
-            "@aws-sdk/middleware-retry": "3.271.0",
-            "@aws-sdk/middleware-serde": "3.271.0",
-            "@aws-sdk/middleware-stack": "3.271.0",
-            "@aws-sdk/middleware-user-agent": "3.271.0",
-            "@aws-sdk/node-config-provider": "3.271.0",
-            "@aws-sdk/node-http-handler": "3.271.0",
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/smithy-client": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/url-parser": "3.271.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.271.0",
-            "@aws-sdk/util-defaults-mode-node": "3.271.0",
-            "@aws-sdk/util-endpoints": "3.271.0",
-            "@aws-sdk/util-retry": "3.271.0",
-            "@aws-sdk/util-user-agent-browser": "3.271.0",
-            "@aws-sdk/util-user-agent-node": "3.271.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.271.0.tgz",
-          "integrity": "sha512-lKZGcDYe8us2Ep7/AjhLyMMTq0NuVt+M+L1eedBGRuGkx/Hrvn4qwlIvSXZhiodoQVa+Wr1zIah3Z06U0dTaZA==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.271.0.tgz",
-          "integrity": "sha512-u3KsjtGBo1SA9HQAVxfA7zHWirlrdKsqsMpnp4eOtixZLoz1e2EytrR5XZem2HND0lzjrUrEPGDPp5OpDtcHxw==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.271.0",
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/url-parser": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.271.0.tgz",
-          "integrity": "sha512-zIclMwXbJeNev74+0tbxLpEO2Js7AhqvR2Msiytz05kOXRyk61NMEavtKRp1YxD2KMptONnvNlbWbNW2rrRDnw==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.271.0",
-            "@aws-sdk/credential-provider-imds": "3.271.0",
-            "@aws-sdk/credential-provider-process": "3.271.0",
-            "@aws-sdk/credential-provider-sso": "3.271.0",
-            "@aws-sdk/credential-provider-web-identity": "3.271.0",
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/shared-ini-file-loader": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.271.0.tgz",
-          "integrity": "sha512-hfdJ+8QM5xXEm4mF4AfIy6T1fVb2zTaUVm5PfPDHtkggVM1L+QSywEkZ2lUqQZMLbbatJqVLy2EMA91k5kjVrA==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.271.0",
-            "@aws-sdk/credential-provider-imds": "3.271.0",
-            "@aws-sdk/credential-provider-ini": "3.271.0",
-            "@aws-sdk/credential-provider-process": "3.271.0",
-            "@aws-sdk/credential-provider-sso": "3.271.0",
-            "@aws-sdk/credential-provider-web-identity": "3.271.0",
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/shared-ini-file-loader": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.271.0.tgz",
-          "integrity": "sha512-Q1HIZYTUYLVe0cNc3HbtFOFzgo3A6PHcmT62T8XClAhFRhkOsJ/KWUybjm8col49/1uqIjKA20E7P7f5Qnn2TQ==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/shared-ini-file-loader": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.271.0.tgz",
-          "integrity": "sha512-TIvsv4xXTME6UsH7g05IzVDCLujaMmgv45A0KcAyM/J/HvFQ9IBOBdyKGU5zIawPvCWXiqQqZs/kDchdB2sjXA==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.271.0",
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/shared-ini-file-loader": "3.271.0",
-            "@aws-sdk/token-providers": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.271.0.tgz",
-          "integrity": "sha512-GD1mg7fMA3ESl0jdzH/+keZHV9Fue/iaGMIWNCUm7M9dOJo0JZbDNzSaMtxZnuA6xtkvw3FiLH6ZxPt0V+7wmg==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.271.0.tgz",
-          "integrity": "sha512-yc0YgKioACFcfs7RPtVHRlpsyYJNdEHkqiWtnRSXG0vuZHAkfvwzchrDK4bizMblnmEV/xbl495ZqDlVbQ0c9A==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/querystring-builder": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/hash-node": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.271.0.tgz",
-          "integrity": "sha512-VamRhkGo2uaVe7KhQhdTqpp9y5JKSFNE3yCUZf/o6lGwL9BgBpBiVqzwCePtas7hAphAaOYvefIwx0XLaCeQ1w==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/invalid-dependency": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.271.0.tgz",
-          "integrity": "sha512-ZN8JmN/t+4UTHkQ6wdod2KKLfJcewLS3D/0iZLnvvOzLlymhcHp9QY8t//RObF+WxnlWeCAvZttoMl/a2MLpYQ==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-content-length": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.271.0.tgz",
-          "integrity": "sha512-bmfqCvjFcowa6jLltJIkGHNXY599Fu9ROoMtYjQiD2ixWHmUpS0I/VivcxXL3uES2qhehxYXyJFyCt7aqRQqcA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-endpoint": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.271.0.tgz",
-          "integrity": "sha512-pibhIe57e68NAfDUY5c7d9zo6WfNwgfclwtrK0nV3OXw9psNeCLGLC1YbzsTun49tm0ICSmkHgmqfsXAVe4HWA==",
-          "requires": {
-            "@aws-sdk/middleware-serde": "3.271.0",
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/signature-v4": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/url-parser": "3.271.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.271.0.tgz",
-          "integrity": "sha512-sp75WZDzDui/Wr3GnQH/db4DXgVdOpKdRQddDsRuULzri8HeJlhMW+JCP+sP0kQmkO06Dagxv1tSmENUxFhPaQ==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.271.0.tgz",
-          "integrity": "sha512-mB/vayfsuc20PySSpbbQ56CPER/RAZF5oGkwGuwFI3bY+VwRun0MOnx3yHj7Ja2DN1ZEOH1Hzrb0eUgREozmHw==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.271.0.tgz",
-          "integrity": "sha512-prrS/YL3GdLODqVBSgxvpUfo9aPBLB3Km5wNBdbhjjN0rI1RqjD+0LquVgaz6C1VU/I8cYbnxrFYtQVcdgnWpg==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.271.0.tgz",
-          "integrity": "sha512-yCBXmxbFGT/4czTi+e4z7lV0nbMWctvvzOtl1ssBiG0LagijIhK4KUp0KTnqDJ+yBqxMpd7wNJ1B0NdS0re6Fw==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/service-error-classification": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/util-middleware": "3.271.0",
-            "@aws-sdk/util-retry": "3.271.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.271.0.tgz",
-          "integrity": "sha512-louPEKEZP2TtTavMwg4k6IJjEbXC6xV05Wtb4I+ZKzjupoTG80nmLtgPU7rnvweej3D69aeSQETfPoq1N4u4mg==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.271.0.tgz",
-          "integrity": "sha512-jCxbt6sehnmV6we2uu0rY5McREJQ9WGQ3HCtjG1qSxm1vJkROX40IUvq7uvwPi3FquqIv2pCc64vLuDdhfs6OA==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/signature-v4": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/util-middleware": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.271.0.tgz",
-          "integrity": "sha512-ojbvxVdJRzvHx1SiXTX8z5qtsX/86+puqqmhTNQTed0/sp856rJVHrE+59qrOa8tNX+dHih5nzmjZ2OvhP+duA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.271.0.tgz",
-          "integrity": "sha512-VnoY5DfdkSorT/bM91FPwHduzkRFBTi/MyU/J08xPkuAQfu2CmvIBr8W15XN1ysAZbZVyDir7NeE9MNG6Q/soA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.271.0.tgz",
-          "integrity": "sha512-PbEQ7GRO9/oXXrxIMPkOsL1lKzi3FzMizFj1tLjSkN+lvUaRt2w9Yrb+P3G7Wr2VyniI8QwpAPnebQ+5Rg7yig==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/shared-ini-file-loader": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.271.0.tgz",
-          "integrity": "sha512-r/wLPLUo3HeWHumvnYxP4LvMz1cKpVO7XVognt5caeDakS2CDiFN3NiCO2PFxOGoWCyMDKcroKtIdXETcgrEbQ==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.271.0",
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/querystring-builder": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/property-provider": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.271.0.tgz",
-          "integrity": "sha512-y95eWGs2tbCESZZVqNWbDXOL43y18bZSS0mfac2n7srOfeuVh+4+8Zdhsnz/NW3Ao61+k1IxKCFnX0iKfJSu2Q==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.271.0.tgz",
-          "integrity": "sha512-WWyS/M+A0NoEBBLbgO1qG7oxEGWvhjsFJgX0Yzz38mKIjW8G/31X9ylaCQoGFSOTn6GXBRqc/i0P86os+wL45Q==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.271.0.tgz",
-          "integrity": "sha512-2FKaoeOgCyn2eShq4hZrEBQ9euHYMvh0aFwWrjQgXjUWJmV4Q+/+eob/sEDeeYvkMW45T5aIG7D+hbVowgWZAQ==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.271.0.tgz",
-          "integrity": "sha512-SGcxf+gaSMMST806zQxETEoe3ENWkncQh+cpDNDRo/oS582PMd7tIOAxP9JJdLJGp9UkIdSkTLWXDjzk9Zt02w==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/service-error-classification": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.271.0.tgz",
-          "integrity": "sha512-yTnxoeCa4uMRfpaaq6oG1h1a01vXQ2al+D0DyX+D5sw7u6RyZOaxxUEbyfEPTN+JtRw+M+zcdlvto3swIwRqoQ=="
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.271.0.tgz",
-          "integrity": "sha512-PR1Hco+r1sH7WlqxaO3Vvl6a8I5juvwVjwjjorbI3EVsxQgEcyCjy1ZVnpCAxY1Xam7ne5nAWO6Y6LtfY4JJ5g==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.271.0.tgz",
-          "integrity": "sha512-OzS+h0MGqzukJSrPqVi08pWDGZkq8U/yXf2LfCkQz58Rv/pbCuDIIN7Oab6IwnVPQV7KoCsegYL3e6BpOp1qpA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.271.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.271.0.tgz",
-          "integrity": "sha512-8wqNArFoLx2hy2kT5jV7JsaZ4jIqI535K1WXBCkzVLKNMv6RVYCBN57I5+C5sgVtHCZwy9RLzRHJIGLEIKIfBg==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.271.0.tgz",
-          "integrity": "sha512-tCh3Pw7VuSGT6yg8n7IeNc25IT8cjPS9Q0YKzjN8rPBZW5iI8/kJyZ7kQBj52JD8WrEYCoxG4hnDvawe1e1lAA==",
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.271.0",
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/shared-ini-file-loader": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.271.0.tgz",
-          "integrity": "sha512-w4oNKEaBul7eh2IM97c89xaH9Ti8+e+u/Rc1ZkgNtpnfOpDUU2t3ugJ91ihGH+xtASQCWJTopTDfX5CuKsQQtQ==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.271.0.tgz",
-          "integrity": "sha512-HuL38pnLaZX4zjlsm9sZfyiPvEK9gFl9viX7wpBJcF50+KgRcj1rasYCy8AfWlCEtL7A214xEutFwGqLfTyDag==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.271.0.tgz",
-          "integrity": "sha512-zyCIT/4PKiBxblZLKcMTNCllKcPhLuE08lIv1fGaqgIZzULFaAGjd/lpTO1q7I2hOt5oFL/4uzTFDrG8g5HJAg==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.271.0.tgz",
-          "integrity": "sha512-QqruC9fkrraoWxrzG7EFX/pOkoLblV2YPsvPHR37DzKSssnsQxOPbiAF95Qw2zocsDrpDuxJEe2RM800vunIsw==",
-          "requires": {
-            "@aws-sdk/config-resolver": "3.271.0",
-            "@aws-sdk/credential-provider-imds": "3.271.0",
-            "@aws-sdk/node-config-provider": "3.271.0",
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.271.0.tgz",
-          "integrity": "sha512-qr+IWZB0Th+TcarjTW5ZakkbKxBNKlLsnFiw3j+gECDA5raUEyTB3w6tRH0nhPFNzN6cM5P8arKlpm3R7f002Q==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.271.0.tgz",
-          "integrity": "sha512-qE+t+JKygIPtXvik1Dy9B2dQx8pJ5NFPms/uFi9kOexCJy8mWd4FApK+sCwT5TGWte+tY2Fg7fcTs5g7ufcsKw==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-retry": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.271.0.tgz",
-          "integrity": "sha512-tO3nHBtAlBSppM37AJNc/rUwLNypPvkDC7av2cyuCDTaH4OHLd/RqZUtvMtSXJKjxR4v8RiyiQvRVE65u0Ermw==",
-          "requires": {
-            "@aws-sdk/service-error-classification": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.271.0.tgz",
-          "integrity": "sha512-nFU4flPzzkG6c46ZKroXtQc6D8g/8ei3nUYJF2Poc+3UD/GiuKASWR+ymALN7Zc2YfR95LcVCNdcm1rDI1WLXA==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.271.0.tgz",
-          "integrity": "sha512-okLJbQ1iBmAH+OdqDd6AmINUAQdLnhi+D9rvp4ZoE5DIhgbzFIuUK6SByB7Rl/9XE76wzkHfRhZJYPyD1cPkQA==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
-      }
-    },
-    "@aws-sdk/config-resolver": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.271.0.tgz",
-      "integrity": "sha512-WNtUjOa9ufKK4+o58YHosjU9J8v494Fb10tHFqD4OspFWLxBKzSJ+r6xpQRcVPucxsmocGJ2QhIiNYo8OySKkA==",
-      "requires": {
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/signature-v4": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.271.0.tgz",
-          "integrity": "sha512-OzS+h0MGqzukJSrPqVi08pWDGZkq8U/yXf2LfCkQz58Rv/pbCuDIIN7Oab6IwnVPQV7KoCsegYL3e6BpOp1qpA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.271.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.271.0.tgz",
-          "integrity": "sha512-w4oNKEaBul7eh2IM97c89xaH9Ti8+e+u/Rc1ZkgNtpnfOpDUU2t3ugJ91ihGH+xtASQCWJTopTDfX5CuKsQQtQ==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.271.0.tgz",
-          "integrity": "sha512-qE+t+JKygIPtXvik1Dy9B2dQx8pJ5NFPms/uFi9kOexCJy8mWd4FApK+sCwT5TGWte+tY2Fg7fcTs5g7ufcsKw==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
+        "@aws-sdk/credential-provider-node": "3.370.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-sdk-sts": "3.370.0",
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.271.0.tgz",
-      "integrity": "sha512-lKZGcDYe8us2Ep7/AjhLyMMTq0NuVt+M+L1eedBGRuGkx/Hrvn4qwlIvSXZhiodoQVa+Wr1zIah3Z06U0dTaZA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.370.0.tgz",
+      "integrity": "sha512-raR3yP/4GGbKFRPP5hUBNkEmTnzxI9mEc2vJAJrcv4G4J4i/UP6ELiLInQ5eO2/VcV/CeKGZA3t7d1tsJ+jhCg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.271.0.tgz",
-      "integrity": "sha512-u3KsjtGBo1SA9HQAVxfA7zHWirlrdKsqsMpnp4eOtixZLoz1e2EytrR5XZem2HND0lzjrUrEPGDPp5OpDtcHxw==",
-      "requires": {
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.271.0.tgz",
-      "integrity": "sha512-zIclMwXbJeNev74+0tbxLpEO2Js7AhqvR2Msiytz05kOXRyk61NMEavtKRp1YxD2KMptONnvNlbWbNW2rrRDnw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.370.0.tgz",
+      "integrity": "sha512-eJyapFKa4NrC9RfTgxlXnXfS9InG/QMEUPPVL+VhG7YS6nKqetC1digOYgivnEeu+XSKE0DJ7uZuXujN2Y7VAQ==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.271.0",
-        "@aws-sdk/credential-provider-imds": "3.271.0",
-        "@aws-sdk/credential-provider-process": "3.271.0",
-        "@aws-sdk/credential-provider-sso": "3.271.0",
-        "@aws-sdk/credential-provider-web-identity": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.370.0",
+        "@aws-sdk/credential-provider-process": "3.370.0",
+        "@aws-sdk/credential-provider-sso": "3.370.0",
+        "@aws-sdk/credential-provider-web-identity": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.271.0.tgz",
-      "integrity": "sha512-hfdJ+8QM5xXEm4mF4AfIy6T1fVb2zTaUVm5PfPDHtkggVM1L+QSywEkZ2lUqQZMLbbatJqVLy2EMA91k5kjVrA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.370.0.tgz",
+      "integrity": "sha512-gkFiotBFKE4Fcn8CzQnMeab9TAR06FEAD02T4ZRYW1xGrBJOowmje9dKqdwQFHSPgnWAP+8HoTA8iwbhTLvjNA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.271.0",
-        "@aws-sdk/credential-provider-imds": "3.271.0",
-        "@aws-sdk/credential-provider-ini": "3.271.0",
-        "@aws-sdk/credential-provider-process": "3.271.0",
-        "@aws-sdk/credential-provider-sso": "3.271.0",
-        "@aws-sdk/credential-provider-web-identity": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.370.0",
+        "@aws-sdk/credential-provider-ini": "3.370.0",
+        "@aws-sdk/credential-provider-process": "3.370.0",
+        "@aws-sdk/credential-provider-sso": "3.370.0",
+        "@aws-sdk/credential-provider-web-identity": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.271.0.tgz",
-      "integrity": "sha512-Q1HIZYTUYLVe0cNc3HbtFOFzgo3A6PHcmT62T8XClAhFRhkOsJ/KWUybjm8col49/1uqIjKA20E7P7f5Qnn2TQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.370.0.tgz",
+      "integrity": "sha512-0BKFFZmUO779Xdw3u7wWnoWhYA4zygxJbgGVSyjkOGBvdkbPSTTcdwT1KFkaQy2kOXYeZPl+usVVRXs+ph4ejg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.271.0.tgz",
-      "integrity": "sha512-TIvsv4xXTME6UsH7g05IzVDCLujaMmgv45A0KcAyM/J/HvFQ9IBOBdyKGU5zIawPvCWXiqQqZs/kDchdB2sjXA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.370.0.tgz",
+      "integrity": "sha512-PFroYm5hcPSfC/jkZnCI34QFL3I7WVKveVk6/F3fud/cnP8hp6YjA9NiTNbqdFSzsyoiN/+e5fZgNKih8vVPTA==",
       "requires": {
-        "@aws-sdk/client-sso": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/token-providers": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.370.0",
+        "@aws-sdk/token-providers": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.271.0.tgz",
-      "integrity": "sha512-GD1mg7fMA3ESl0jdzH/+keZHV9Fue/iaGMIWNCUm7M9dOJo0JZbDNzSaMtxZnuA6xtkvw3FiLH6ZxPt0V+7wmg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.370.0.tgz",
+      "integrity": "sha512-CFaBMLRudwhjv1sDzybNV93IaT85IwS+L8Wq6VRMa0mro1q9rrWsIZO811eF+k0NEPfgU1dLH+8Vc2qhw4SARQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.271.0.tgz",
-      "integrity": "sha512-yc0YgKioACFcfs7RPtVHRlpsyYJNdEHkqiWtnRSXG0vuZHAkfvwzchrDK4bizMblnmEV/xbl495ZqDlVbQ0c9A==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/querystring-builder": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.271.0.tgz",
-      "integrity": "sha512-VamRhkGo2uaVe7KhQhdTqpp9y5JKSFNE3yCUZf/o6lGwL9BgBpBiVqzwCePtas7hAphAaOYvefIwx0XLaCeQ1w==",
-      "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.271.0.tgz",
-      "integrity": "sha512-ZN8JmN/t+4UTHkQ6wdod2KKLfJcewLS3D/0iZLnvvOzLlymhcHp9QY8t//RObF+WxnlWeCAvZttoMl/a2MLpYQ==",
-      "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/md5-js": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.271.0.tgz",
-      "integrity": "sha512-WzgLeDxWg8d8jARXhVc2M/+PyolkTyR0VWoIqdAPnQdLAHisUq3NxM1Ufp9e6Z4SIFW3ovtG84GHFBxSeFp/cw==",
-      "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.271.0.tgz",
-      "integrity": "sha512-bmfqCvjFcowa6jLltJIkGHNXY599Fu9ROoMtYjQiD2ixWHmUpS0I/VivcxXL3uES2qhehxYXyJFyCt7aqRQqcA==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-endpoint": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.271.0.tgz",
-      "integrity": "sha512-pibhIe57e68NAfDUY5c7d9zo6WfNwgfclwtrK0nV3OXw9psNeCLGLC1YbzsTun49tm0ICSmkHgmqfsXAVe4HWA==",
-      "requires": {
-        "@aws-sdk/middleware-serde": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/url-parser": "3.271.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.271.0.tgz",
-      "integrity": "sha512-sp75WZDzDui/Wr3GnQH/db4DXgVdOpKdRQddDsRuULzri8HeJlhMW+JCP+sP0kQmkO06Dagxv1tSmENUxFhPaQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.370.0.tgz",
+      "integrity": "sha512-CPXOm/TnOFC7KyXcJglICC7OiA7Kj6mT3ChvEijr56TFOueNHvJdV4aNIFEQy0vGHOWtY12qOWLNto/wYR1BAQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.271.0.tgz",
-      "integrity": "sha512-mB/vayfsuc20PySSpbbQ56CPER/RAZF5oGkwGuwFI3bY+VwRun0MOnx3yHj7Ja2DN1ZEOH1Hzrb0eUgREozmHw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.370.0.tgz",
+      "integrity": "sha512-cQMq9SaZ/ORmTJPCT6VzMML7OxFdQzNkhMAgKpTDl+tdPWynlHF29E5xGoSzROnThHlQPCjogU0NZ8AxI0SWPA==",
       "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.271.0.tgz",
-      "integrity": "sha512-prrS/YL3GdLODqVBSgxvpUfo9aPBLB3Km5wNBdbhjjN0rI1RqjD+0LquVgaz6C1VU/I8cYbnxrFYtQVcdgnWpg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.370.0.tgz",
+      "integrity": "sha512-L7ZF/w0lAAY/GK1khT8VdoU0XB7nWHk51rl/ecAg64J70dHnMOAg8n+5FZ9fBu/xH1FwUlHOkwlodJOgzLJjtg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.271.0.tgz",
-      "integrity": "sha512-yCBXmxbFGT/4czTi+e4z7lV0nbMWctvvzOtl1ssBiG0LagijIhK4KUp0KTnqDJ+yBqxMpd7wNJ1B0NdS0re6Fw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/service-error-classification": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "@aws-sdk/util-retry": "3.271.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.271.0.tgz",
-      "integrity": "sha512-9R25mEaxcTrF/YI4m4drMYvLFvEEyCCrQEpls3WXGUbeRcwOGAhLqKmdwKf/bMkG1SDMx+OLrzzmk9DLa7J83g==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.370.0.tgz",
+      "integrity": "sha512-jk61LjuxYe3gfcxuPsAPuKCycTGC7bhd8VHGBjlndLmYIG6Y6t668fvVXTKsz+CWQLTpAjhkS8ON2nJKiMqaQw==",
       "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-hex-encoding": "^1.0.1",
+        "@smithy/util-utf8": "^1.0.1",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.271.0.tgz",
-      "integrity": "sha512-/h8+PAx+85M+tSL/kl1lWVgHrrodmDRuQuDLXC7ufE6C1JRxRBkWMTOg6S3ZeuKo1Va/8RcAKf7jtkGdIBD5HQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.370.0.tgz",
+      "integrity": "sha512-ykbsoVy0AJtVbuhAlTAMcaz/tCE3pT8nAp0L7CQQxSoanRCvOux7au0KwMIQVhxgnYid4dWVF6d00SkqU5MXRA==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/middleware-signing": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.271.0.tgz",
-          "integrity": "sha512-jCxbt6sehnmV6we2uu0rY5McREJQ9WGQ3HCtjG1qSxm1vJkROX40IUvq7uvwPi3FquqIv2pCc64vLuDdhfs6OA==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.271.0",
-            "@aws-sdk/protocol-http": "3.271.0",
-            "@aws-sdk/signature-v4": "3.271.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/util-middleware": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/property-provider": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.271.0.tgz",
-          "integrity": "sha512-y95eWGs2tbCESZZVqNWbDXOL43y18bZSS0mfac2n7srOfeuVh+4+8Zdhsnz/NW3Ao61+k1IxKCFnX0iKfJSu2Q==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.271.0.tgz",
-          "integrity": "sha512-WWyS/M+A0NoEBBLbgO1qG7oxEGWvhjsFJgX0Yzz38mKIjW8G/31X9ylaCQoGFSOTn6GXBRqc/i0P86os+wL45Q==",
-          "requires": {
-            "@aws-sdk/types": "3.271.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.271.0.tgz",
-          "integrity": "sha512-OzS+h0MGqzukJSrPqVi08pWDGZkq8U/yXf2LfCkQz58Rv/pbCuDIIN7Oab6IwnVPQV7KoCsegYL3e6BpOp1qpA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.271.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.271.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.271.0.tgz",
-          "integrity": "sha512-w4oNKEaBul7eh2IM97c89xaH9Ti8+e+u/Rc1ZkgNtpnfOpDUU2t3ugJ91ihGH+xtASQCWJTopTDfX5CuKsQQtQ==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.271.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.271.0.tgz",
-          "integrity": "sha512-qE+t+JKygIPtXvik1Dy9B2dQx8pJ5NFPms/uFi9kOexCJy8mWd4FApK+sCwT5TGWte+tY2Fg7fcTs5g7ufcsKw==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.271.0.tgz",
-      "integrity": "sha512-louPEKEZP2TtTavMwg4k6IJjEbXC6xV05Wtb4I+ZKzjupoTG80nmLtgPU7rnvweej3D69aeSQETfPoq1N4u4mg==",
-      "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.271.0.tgz",
-      "integrity": "sha512-jCxbt6sehnmV6we2uu0rY5McREJQ9WGQ3HCtjG1qSxm1vJkROX40IUvq7uvwPi3FquqIv2pCc64vLuDdhfs6OA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.370.0.tgz",
+      "integrity": "sha512-Dwr/RTCWOXdm394wCwICGT2VNOTMRe4IGPsBRJAsM24pm+EEqQzSS3Xu/U/zF4exuxqpMta4wec4QpSarPNTxA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/signature-v4": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.271.0.tgz",
-      "integrity": "sha512-ojbvxVdJRzvHx1SiXTX8z5qtsX/86+puqqmhTNQTed0/sp856rJVHrE+59qrOa8tNX+dHih5nzmjZ2OvhP+duA==",
-      "requires": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/signature-v4": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.271.0.tgz",
-      "integrity": "sha512-VnoY5DfdkSorT/bM91FPwHduzkRFBTi/MyU/J08xPkuAQfu2CmvIBr8W15XN1ysAZbZVyDir7NeE9MNG6Q/soA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.370.0.tgz",
+      "integrity": "sha512-2+3SB6MtMAq1+gVXhw0Y3ONXuljorh6ijnxgTpv+uQnBW5jHCUiAS8WDYiDEm7i9euJPbvJfM8WUrSMDMU6Cog==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.271.0.tgz",
-      "integrity": "sha512-PbEQ7GRO9/oXXrxIMPkOsL1lKzi3FzMizFj1tLjSkN+lvUaRt2w9Yrb+P3G7Wr2VyniI8QwpAPnebQ+5Rg7yig==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.271.0.tgz",
-      "integrity": "sha512-r/wLPLUo3HeWHumvnYxP4LvMz1cKpVO7XVognt5caeDakS2CDiFN3NiCO2PFxOGoWCyMDKcroKtIdXETcgrEbQ==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.271.0",
-        "@aws-sdk/protocol-http": "3.271.0",
-        "@aws-sdk/querystring-builder": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.271.0.tgz",
-      "integrity": "sha512-y95eWGs2tbCESZZVqNWbDXOL43y18bZSS0mfac2n7srOfeuVh+4+8Zdhsnz/NW3Ao61+k1IxKCFnX0iKfJSu2Q==",
-      "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.271.0.tgz",
-      "integrity": "sha512-WWyS/M+A0NoEBBLbgO1qG7oxEGWvhjsFJgX0Yzz38mKIjW8G/31X9ylaCQoGFSOTn6GXBRqc/i0P86os+wL45Q==",
-      "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.271.0.tgz",
-      "integrity": "sha512-2FKaoeOgCyn2eShq4hZrEBQ9euHYMvh0aFwWrjQgXjUWJmV4Q+/+eob/sEDeeYvkMW45T5aIG7D+hbVowgWZAQ==",
-      "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.271.0.tgz",
-      "integrity": "sha512-SGcxf+gaSMMST806zQxETEoe3ENWkncQh+cpDNDRo/oS582PMd7tIOAxP9JJdLJGp9UkIdSkTLWXDjzk9Zt02w==",
-      "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.271.0.tgz",
-      "integrity": "sha512-yTnxoeCa4uMRfpaaq6oG1h1a01vXQ2al+D0DyX+D5sw7u6RyZOaxxUEbyfEPTN+JtRw+M+zcdlvto3swIwRqoQ=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.271.0.tgz",
-      "integrity": "sha512-PR1Hco+r1sH7WlqxaO3Vvl6a8I5juvwVjwjjorbI3EVsxQgEcyCjy1ZVnpCAxY1Xam7ne5nAWO6Y6LtfY4JJ5g==",
-      "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.271.0.tgz",
-      "integrity": "sha512-OzS+h0MGqzukJSrPqVi08pWDGZkq8U/yXf2LfCkQz58Rv/pbCuDIIN7Oab6IwnVPQV7KoCsegYL3e6BpOp1qpA==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.271.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.271.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.271.0.tgz",
-      "integrity": "sha512-8wqNArFoLx2hy2kT5jV7JsaZ4jIqI535K1WXBCkzVLKNMv6RVYCBN57I5+C5sgVtHCZwy9RLzRHJIGLEIKIfBg==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.271.0.tgz",
-      "integrity": "sha512-tCh3Pw7VuSGT6yg8n7IeNc25IT8cjPS9Q0YKzjN8rPBZW5iI8/kJyZ7kQBj52JD8WrEYCoxG4hnDvawe1e1lAA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.370.0.tgz",
+      "integrity": "sha512-EyR2ZYr+lJeRiZU2/eLR+mlYU9RXLQvNyGFSAekJKgN13Rpq/h0syzXVFLP/RSod/oZenh/fhVZ2HwlZxuGBtQ==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/shared-ini-file-loader": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso-oidc": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.271.0.tgz",
-      "integrity": "sha512-w4oNKEaBul7eh2IM97c89xaH9Ti8+e+u/Rc1ZkgNtpnfOpDUU2t3ugJ91ihGH+xtASQCWJTopTDfX5CuKsQQtQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
+      "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
       "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/url-parser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.271.0.tgz",
-      "integrity": "sha512-HuL38pnLaZX4zjlsm9sZfyiPvEK9gFl9viX7wpBJcF50+KgRcj1rasYCy8AfWlCEtL7A214xEutFwGqLfTyDag==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-base64": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.271.0.tgz",
-      "integrity": "sha512-zyCIT/4PKiBxblZLKcMTNCllKcPhLuE08lIv1fGaqgIZzULFaAGjd/lpTO1q7I2hOt5oFL/4uzTFDrG8g5HJAg==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.271.0.tgz",
-      "integrity": "sha512-QqruC9fkrraoWxrzG7EFX/pOkoLblV2YPsvPHR37DzKSssnsQxOPbiAF95Qw2zocsDrpDuxJEe2RM800vunIsw==",
-      "requires": {
-        "@aws-sdk/config-resolver": "3.271.0",
-        "@aws-sdk/credential-provider-imds": "3.271.0",
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/property-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.271.0.tgz",
-      "integrity": "sha512-qr+IWZB0Th+TcarjTW5ZakkbKxBNKlLsnFiw3j+gECDA5raUEyTB3w6tRH0nhPFNzN6cM5P8arKlpm3R7f002Q==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.370.0.tgz",
+      "integrity": "sha512-5ltVAnM79nRlywwzZN5i8Jp4tk245OCGkKwwXbnDU+gq7zT3CIOsct1wNZvmpfZEPGt/bv7/NyRcjP+7XNsX/g==",
       "requires": {
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-      "requires": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -5880,58 +3500,26 @@
         "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/util-middleware": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.271.0.tgz",
-      "integrity": "sha512-qE+t+JKygIPtXvik1Dy9B2dQx8pJ5NFPms/uFi9kOexCJy8mWd4FApK+sCwT5TGWte+tY2Fg7fcTs5g7ufcsKw==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-retry": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.271.0.tgz",
-      "integrity": "sha512-tO3nHBtAlBSppM37AJNc/rUwLNypPvkDC7av2cyuCDTaH4OHLd/RqZUtvMtSXJKjxR4v8RiyiQvRVE65u0Ermw==",
-      "requires": {
-        "@aws-sdk/service-error-classification": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.271.0.tgz",
-      "integrity": "sha512-nFU4flPzzkG6c46ZKroXtQc6D8g/8ei3nUYJF2Poc+3UD/GiuKASWR+ymALN7Zc2YfR95LcVCNdcm1rDI1WLXA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.370.0.tgz",
+      "integrity": "sha512-028LxYZMQ0DANKhW+AKFQslkScZUeYlPmSphrCIXgdIItRZh6ZJHGzE7J/jDsEntZOrZJsjI4z0zZ5W2idj04w==",
       "requires": {
-        "@aws-sdk/types": "3.271.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.271.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.271.0.tgz",
-      "integrity": "sha512-okLJbQ1iBmAH+OdqDd6AmINUAQdLnhi+D9rvp4ZoE5DIhgbzFIuUK6SByB7Rl/9XE76wzkHfRhZJYPyD1cPkQA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.370.0.tgz",
+      "integrity": "sha512-33vxZUp8vxTT/DGYIR3PivQm07sSRGWI+4fCv63Rt7Q++fO24E0kQtmVAlikRY810I10poD6rwILVtITtFSzkg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.271.0",
-        "@aws-sdk/types": "3.271.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-utf8": {
-      "version": "3.254.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
-      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-utf8-browser": {
@@ -5946,7 +3534,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.2.tgz",
       "integrity": "sha512-tb2h0b+JvMee+eAxTmhnyqyNk51UXIK949HnE14lFeezKsVJTB30maan+CO2IMwnig2wVYQH84B5qk6ylmKCuA==",
-      "peer": true,
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -5956,7 +3543,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.2.tgz",
       "integrity": "sha512-8Bk7CgnVKg1dn5TgnjwPz2ebhxeR7CjGs5yhVYH3S8x0q8yPZZVWwpRIglwXaf5AZBzJlNO1lh+lUhMf2e73zQ==",
-      "peer": true,
       "requires": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-config-provider": "^1.0.2",
@@ -5968,7 +3554,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.2.tgz",
       "integrity": "sha512-fLjCya+JOu2gPJpCiwSUyoLvT8JdNJmOaTOkKYBZoGf7CzqR6lluSyI+eboZnl/V0xqcfcqBG4tgqCISmWS3/w==",
-      "peer": true,
       "requires": {
         "@smithy/node-config-provider": "^1.0.2",
         "@smithy/property-provider": "^1.0.2",
@@ -5981,7 +3566,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.2.tgz",
       "integrity": "sha512-eW/XPiLauR1VAgHKxhVvgvHzLROUgTtqat2lgljztbH8uIYWugv7Nz+SgCavB+hWRazv2iYgqrSy74GvxXq/rg==",
-      "peer": true,
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^1.1.1",
@@ -6036,7 +3620,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.2.tgz",
       "integrity": "sha512-kynyofLf62LvR8yYphPPdyHb8fWG3LepFinM/vWUTG2Q1pVpmPCM530ppagp3+q2p+7Ox0UvSqldbKqV/d1BpA==",
-      "peer": true,
       "requires": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/querystring-builder": "^1.0.2",
@@ -6049,7 +3632,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.2.tgz",
       "integrity": "sha512-K6PKhcUNrJXtcesyzhIvNlU7drfIU7u+EMQuGmPw6RQDAg/ufUcfKHz4EcUhFAodUmN+rrejhRG9U6wxjeBOQA==",
-      "peer": true,
       "requires": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-buffer-from": "^1.0.2",
@@ -6061,18 +3643,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.2.tgz",
       "integrity": "sha512-B1Y3Tsa6dfC+Vvb+BJMhTHOfFieeYzY9jWQSTR1vMwKkxsymD0OIAnEw8rD/RiDj/4E4RPGFdx9Mdgnyd6Bv5Q==",
-      "peer": true,
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/is-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-pkyBnsBRpe+c/6ASavqIMRBdRtZNJEVJOEzhpxZ9JoAXiZYbkfaSMRA/O1dUxGdJ653GHONunnZ4xMo/LJ7utQ==",
-      "peer": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz",
+      "integrity": "sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==",
       "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/md5-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-1.1.0.tgz",
+      "integrity": "sha512-ftB+GrB/AgF+NlaoVMc3wlXZxsAcenrq2inrc6FfwM2tXUmU2Oc1W3qVW7rIDNqR6GmvXkAIxlnp6P2QkwlkNw==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-utf8": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6080,7 +3670,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.2.tgz",
       "integrity": "sha512-pa1/SgGIrSmnEr2c9Apw7CdU4l/HW0fK3+LKFCPDYJrzM0JdYpqjQzgxi31P00eAkL0EFBccpus/p1n2GF9urw==",
-      "peer": true,
       "requires": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/types": "^1.1.1",
@@ -6091,7 +3680,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz",
       "integrity": "sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==",
-      "peer": true,
       "requires": {
         "@smithy/middleware-serde": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -6104,7 +3692,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz",
       "integrity": "sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==",
-      "peer": true,
       "requires": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/service-error-classification": "^1.0.3",
@@ -6118,8 +3705,7 @@
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "peer": true
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -6127,7 +3713,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz",
       "integrity": "sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==",
-      "peer": true,
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -6137,7 +3722,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.2.tgz",
       "integrity": "sha512-H7/uAQEcmO+eDqweEFMJ5YrIpsBwmrXSP6HIIbtxKJSQpAcMGY7KrR2FZgZBi1FMnSUOh+rQrbOyj5HQmSeUBA==",
-      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -6146,7 +3730,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.2.tgz",
       "integrity": "sha512-HU7afWpTToU0wL6KseGDR2zojeyjECQfr8LpjAIeHCYIW7r360ABFf4EaplaJRMVoC3hD9FeltgI3/NtShOqCg==",
-      "peer": true,
       "requires": {
         "@smithy/property-provider": "^1.0.2",
         "@smithy/shared-ini-file-loader": "^1.0.2",
@@ -6158,7 +3741,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.3.tgz",
       "integrity": "sha512-PcPUSzTbIb60VCJCiH0PU0E6bwIekttsIEf5Aoo/M0oTfiqsxHTn0Rcij6QoH6qJy6piGKXzLSegspXg5+Kq6g==",
-      "peer": true,
       "requires": {
         "@smithy/abort-controller": "^1.0.2",
         "@smithy/protocol-http": "^1.1.1",
@@ -6171,7 +3753,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.2.tgz",
       "integrity": "sha512-pXDPyzKX8opzt38B205kDgaxda6LHcTfPvTYQZnwP6BAPp1o9puiCPjeUtkKck7Z6IbpXCPUmUQnzkUzWTA42Q==",
-      "peer": true,
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -6181,7 +3762,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
       "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
-      "peer": true,
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -6191,7 +3771,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.2.tgz",
       "integrity": "sha512-6P/xANWrtJhMzTPUR87AbXwSBuz1SDHIfL44TFd/GT3hj6rA+IEv7rftEpPjayUiWRocaNnrCPLvmP31mobOyA==",
-      "peer": true,
       "requires": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-uri-escape": "^1.0.2",
@@ -6202,7 +3781,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz",
       "integrity": "sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==",
-      "peer": true,
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -6211,14 +3789,12 @@
     "@smithy/service-error-classification": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz",
-      "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA==",
-      "peer": true
+      "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA=="
     },
     "@smithy/shared-ini-file-loader": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.2.tgz",
       "integrity": "sha512-bdQj95VN+lCXki+P3EsDyrkpeLn8xDYiOISBGnUG/AGPYJXN8dmp4EhRRR7XOoLoSs8anZHR4UcGEOzFv2jwGw==",
-      "peer": true,
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -6228,7 +3804,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.2.tgz",
       "integrity": "sha512-rpKUhmCuPmpV5dloUkOb9w1oBnJatvKQEjIHGmkjRGZnC3437MTdzWej9TxkagcZ8NRRJavYnEUixzxM1amFig==",
-      "peer": true,
       "requires": {
         "@smithy/eventstream-codec": "^1.0.2",
         "@smithy/is-array-buffer": "^1.0.2",
@@ -6244,7 +3819,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.4.tgz",
       "integrity": "sha512-gpo0Xl5Nyp9sgymEfpt7oa9P2q/GlM3VmQIdm+FeH0QEdYOQx3OtvwVmBYAMv2FIPWxkMZlsPYRTnEiBTK5TYg==",
-      "peer": true,
       "requires": {
         "@smithy/middleware-stack": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -6253,10 +3827,9 @@
       }
     },
     "@smithy/types": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
-      "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
-      "peer": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -6265,7 +3838,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.2.tgz",
       "integrity": "sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==",
-      "peer": true,
       "requires": {
         "@smithy/querystring-parser": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -6276,7 +3848,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.2.tgz",
       "integrity": "sha512-BCm15WILJ3SL93nusoxvJGMVfAMWHZhdeDZPtpAaskozuexd0eF6szdz4kbXaKp38bFCSenA6bkUHqaE3KK0dA==",
-      "peer": true,
       "requires": {
         "@smithy/util-buffer-from": "^1.0.2",
         "tslib": "^2.5.0"
@@ -6286,7 +3857,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.2.tgz",
       "integrity": "sha512-Xh8L06H2anF5BHjSYTg8hx+Itcbf4SQZnVMl4PIkCOsKtneMJoGjPRLy17lEzfoh/GOaa0QxgCP6lRMQWzNl4w==",
-      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -6295,18 +3865,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.2.tgz",
       "integrity": "sha512-nXHbZsUtvZeyfL4Ceds9nmy2Uh2AhWXohG4vWHyjSdmT8cXZlJdmJgnH6SJKDjyUecbu+BpKeVvSrA4cWPSOPA==",
-      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-buffer-from": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.2.tgz",
-      "integrity": "sha512-lHAYIyrBO9RANrPvccnPjU03MJnWZ66wWuC5GjWWQVfsmPwU6m00aakZkzHdUT6tGCkGacXSgArP5wgTgA+oCw==",
-      "peer": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz",
+      "integrity": "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==",
       "requires": {
-        "@smithy/is-array-buffer": "^1.0.2",
+        "@smithy/is-array-buffer": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6314,7 +3882,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.2.tgz",
       "integrity": "sha512-HOdmDm+3HUbuYPBABLLHtn8ittuRyy+BSjKOA169H+EMc+IozipvXDydf+gKBRAxUa4dtKQkLraypwppzi+PRw==",
-      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -6323,7 +3890,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.2.tgz",
       "integrity": "sha512-J1u2PO235zxY7dg0+ZqaG96tFg4ehJZ7isGK1pCBEA072qxNPwIpDzUVGnLJkHZvjWEGA8rxIauDtXfB0qxeAg==",
-      "peer": true,
       "requires": {
         "@smithy/property-provider": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -6335,7 +3901,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.2.tgz",
       "integrity": "sha512-9/BN63rlIsFStvI+AvljMh873Xw6bbI6b19b+PVYXyycQ2DDQImWcjnzRlHW7eP65CCUNGQ6otDLNdBQCgMXqg==",
-      "peer": true,
       "requires": {
         "@smithy/config-resolver": "^1.0.2",
         "@smithy/credential-provider-imds": "^1.0.2",
@@ -6349,7 +3914,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.2.tgz",
       "integrity": "sha512-Bxydb5rMJorMV6AuDDMOxro3BMDdIwtbQKHpwvQFASkmr52BnpDsWlxgpJi8Iq7nk1Bt4E40oE1Isy/7ubHGzg==",
-      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -6358,7 +3922,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.2.tgz",
       "integrity": "sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==",
-      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -6367,7 +3930,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.4.tgz",
       "integrity": "sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==",
-      "peer": true,
       "requires": {
         "@smithy/service-error-classification": "^1.0.3",
         "tslib": "^2.5.0"
@@ -6377,7 +3939,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.2.tgz",
       "integrity": "sha512-qyN2M9QFMTz4UCHi6GnBfLOGYKxQZD01Ga6nzaXFFC51HP/QmArU72e4kY50Z/EtW8binPxspP2TAsGbwy9l3A==",
-      "peer": true,
       "requires": {
         "@smithy/fetch-http-handler": "^1.0.2",
         "@smithy/node-http-handler": "^1.0.3",
@@ -6393,18 +3954,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.2.tgz",
       "integrity": "sha512-k8C0BFNS9HpBMHSgUDnWb1JlCQcFG+PPlVBq9keP4Nfwv6a9Q0yAfASWqUCtzjuMj1hXeLhn/5ADP6JxnID1Pg==",
-      "peer": true,
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-utf8": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.2.tgz",
-      "integrity": "sha512-V4cyjKfJlARui0dMBfWJMQAmJzoW77i4N3EjkH/bwnE2Ngbl4tqD2Y0C/xzpzY/J1BdxeCKxAebVFk8aFCaSCw==",
-      "peer": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.1.0.tgz",
+      "integrity": "sha512-p/MYV+JmqmPyjdgyN2UxAeYDj9cBqCjp0C/NsTWnnjoZUVqoeZ6IrW915L9CAKWVECgv9lVQGc4u/yz26/bI1A==",
       "requires": {
-        "@smithy/util-buffer-from": "^1.0.2",
+        "@smithy/util-buffer-from": "^1.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6445,9 +4004,9 @@
       }
     },
     "fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "requires": {
         "strnum": "^1.0.5"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rewaa/event-broker",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rewaa/event-broker",
-      "version": "4.0.1",
+      "version": "5.0.0",
       "license": "ISC",
       "dependencies": {
         "sqs-consumer": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rewaa/event-broker",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "A broker for all the events that Rewaa will ever produce or consume",
   "main": "dist/index.js",
   "scripts": {

--- a/src/emitters/emitter.ts
+++ b/src/emitters/emitter.ts
@@ -14,20 +14,20 @@ import {
   Queue,
   Topic,
 } from "../types";
-import { Logger } from "../utils/utils";
 import { SqnsEmitter } from "./emitter.sqns";
+import { Logger } from "../utils/utils";
 
 export class Emitter implements IEmitter {
   private localEmitter: EventEmitter = new EventEmitter();
   private emitter!: IEmitter;
   private options!: IEmitterOptions;
+  private logger;
 
   constructor(options: IEmitterOptions) {
     this.options = options;
-    this.options.localEmitter = this.localEmitter;
-    Logger.logsEnabled = !!this.options.log;
+    this.logger = options.logger ?? new Logger(!!this.options.log);
     if (this.options.useExternalBroker) {
-      this.emitter = new SqnsEmitter(this.options);
+      this.emitter = new SqnsEmitter(this.logger, this.options, );
     }
   }
 

--- a/src/emitters/emitter.ts
+++ b/src/emitters/emitter.ts
@@ -15,14 +15,14 @@ import {
   Topic,
 } from "../types";
 import { SqnsEmitter } from "./emitter.sqns";
-import { Logger as LoggerI } from "../types";
+import { Logger as ILogger } from "../types";
 import { Logger } from "../utils/utils";
 
 export class Emitter implements IEmitter {
   private localEmitter: EventEmitter = new EventEmitter();
   private emitter!: IEmitter;
   private options!: IEmitterOptions;
-  private logger: LoggerI;
+  private logger: ILogger;
 
   constructor(options: IEmitterOptions) {
     this.options = options;

--- a/src/emitters/emitter.ts
+++ b/src/emitters/emitter.ts
@@ -15,13 +15,14 @@ import {
   Topic,
 } from "../types";
 import { SqnsEmitter } from "./emitter.sqns";
+import { Logger as LoggerI } from "../types";
 import { Logger } from "../utils/utils";
 
 export class Emitter implements IEmitter {
   private localEmitter: EventEmitter = new EventEmitter();
   private emitter!: IEmitter;
   private options!: IEmitterOptions;
-  private logger;
+  private logger: LoggerI;
 
   constructor(options: IEmitterOptions) {
     this.options = options;

--- a/src/producers/producer.sns.ts
+++ b/src/producers/producer.sns.ts
@@ -9,13 +9,15 @@ import {
   PublishBatchResponse,
   PublishBatchInput
 } from "@aws-sdk/client-sns";
-import { ISNSMessage } from "../types";
-import { Logger } from "../utils/utils";
+import { ISNSMessage, Logger } from "../types";
 import { v4 } from "uuid";
 
 export class SNSProducer {
   private readonly sns: SNS;
-  constructor(config: SNSClientConfig) {
+  constructor(
+    private readonly logger: Logger,
+    config: SNSClientConfig
+  ) {
     this.sns = new SNS(config);
   }
 
@@ -82,7 +84,7 @@ export class SNSProducer {
       const { TopicArn } = await this.sns.createTopic(params);
       return TopicArn;
     } catch (error) {
-      Logger.error(`Topic creation failed: ${topicName}`);
+      this.logger.error(`Topic creation failed: ${topicName}`);
       throw error;
     }
   };
@@ -107,7 +109,7 @@ export class SNSProducer {
     try {
       return await this.sns.subscribe(params);
     } catch (error) {
-      Logger.error(`Topic subscription failed: ${queueArn} to ${topicArn}`);
+      this.logger.error(`Topic subscription failed: ${queueArn} to ${topicArn}`);
       throw error;
     }
   };

--- a/src/producers/producer.sqs.ts
+++ b/src/producers/producer.sqs.ts
@@ -18,9 +18,9 @@ import {
   IMessage,
   ISQSMessage,
   ISQSMessageOptions,
+  Logger,
   Topic,
 } from "../types";
-import { Logger } from "../utils/utils";
 import {
   DEFAULT_MESSAGE_DELAY,
   DEFAULT_DLQ_MESSAGE_RETENTION_PERIOD,
@@ -32,7 +32,10 @@ import { v4 } from "uuid";
 
 export class SQSProducer {
   private readonly sqs: SQS;
-  constructor(config: SQSClientConfig) {
+  constructor(
+    private readonly logger: Logger,
+    config: SQSClientConfig
+  ) {
     this.sqs = new SQS(config);
   }
 
@@ -101,7 +104,7 @@ export class SQSProducer {
       const { QueueUrl } = await this.sqs.createQueue(params);
       return QueueUrl;
     } catch (error) {
-      Logger.error(`Queue creation failed: ${queueName}`);
+      this.logger.error(`Queue creation failed: ${queueName}`);
       throw error;
     }
   };
@@ -175,7 +178,7 @@ export class SQSProducer {
         .getQueueAttributes(params);
       return Attributes;
     } catch (error) {
-      Logger.error(`Failed to fetch queue attributes: ${queueUrl}`);
+      this.logger.error(`Failed to fetch queue attributes: ${queueUrl}`);
       throw error;
     }
   };
@@ -188,7 +191,7 @@ export class SQSProducer {
       await this.sqs.deleteQueue(params);
       return true;
     } catch (error) {
-      Logger.error(`Queue deletion failed: ${queueUrl}`);
+      this.logger.error(`Queue deletion failed: ${queueUrl}`);
       throw error;
     }
   };
@@ -205,7 +208,7 @@ export class SQSProducer {
       await this.sqs.deleteMessage(params);
       return true;
     } catch (error) {
-      Logger.error(`Message deletion failed: ${queueUrl} - ${receiptHandle}`);
+      this.logger.error(`Message deletion failed: ${queueUrl} - ${receiptHandle}`);
       throw error;
     }
   };
@@ -225,7 +228,7 @@ export class SQSProducer {
       await this.sqs.deleteMessageBatch(params);
       return true;
     } catch (error) {
-      Logger.error(
+      this.logger.error(
         `Batch message deletion failed: ${queueUrl} - ${receiptHandles}`
       );
       throw error;
@@ -240,7 +243,7 @@ export class SQSProducer {
       const result = await this.sqs.getQueueUrl(params);
       return result.QueueUrl;
     } catch (error) {
-      Logger.error(`Queue not found, creating new: ${queueName} \n ${error}`);
+      this.logger.error(`Queue not found, creating new: ${queueName} \n ${error}`);
       return undefined;
     }
   };
@@ -256,7 +259,7 @@ export class SQSProducer {
     try {
       await this.sqs.setQueueAttributes(params);
     } catch (error) {
-      Logger.error(`setQueueAttributes failed for queueUrl: ${queueUrl}`);
+      this.logger.error(`setQueueAttributes failed for queueUrl: ${queueUrl}`);
       throw error;
     }
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,21 +3,12 @@ import { Consumer } from "sqs-consumer";
 import { MessageAttributeValue, SQSClientConfig, Message } from "@aws-sdk/client-sqs";
 import { SNSClientConfig } from "@aws-sdk/client-sns";
 import { LambdaClientConfig } from "@aws-sdk/client-lambda";
-import { AsyncLocalStorage } from "async_hooks";
 
 export interface Logger {
   error(error: any): void;
   warn(message: any): void;
   debug(message: any): void;
   info(message: any): void;
-  /**
-   * @returns Returns the async local storage and store which will be used to call the message handler
-   * so that the other log functions and those logs that the service itself does happen in the same context
-   */
-  getStore?: (executionContext?: ProcessMessageContext) => ({
-    storage: AsyncLocalStorage<unknown>,
-    store: unknown,
-  });
 }
 
 export interface IMessage {
@@ -334,7 +325,13 @@ export type DefaultQueueOptions = Omit<
   "separateConsumerGroup" | "isFifo" | "exchangeType"
 >;
 
-export type EventListener<T> = (...args: T[]) => Promise<void>;
+export interface MessageMetaData {
+  executionTraceId: string;
+  messageId?: string;
+  messageAttributes?: { [key: string]: MessageAttributeValue };
+}
+
+export type EventListener<T> = (args: T[], metadata?: MessageMetaData) => Promise<void>;
 
 export interface IEmitter {
   /**

--- a/src/utils/lambda.client.ts
+++ b/src/utils/lambda.client.ts
@@ -5,12 +5,14 @@ import {
   CreateEventSourceMappingRequest,
   ListEventSourceMappingsRequest,
 } from "@aws-sdk/client-lambda";
-import { ICreateQueueLambdaEventSourceInput } from "../types";
-import { Logger } from "./utils";
+import { ICreateQueueLambdaEventSourceInput, Logger } from "../types";
 
 export class LambdaClient {
   private readonly lambda: Lambda;
-  constructor(config: LambdaClientConfig) {
+  constructor(
+    private readonly logger: Logger,
+    config: LambdaClientConfig
+  ) {
     this.lambda = new Lambda(config);
   }
 
@@ -45,13 +47,13 @@ export class LambdaClient {
       }
       return await this.client.createEventSourceMapping(params);
     } catch (error: any) {
-      Logger.error(
+      this.logger.error(
         `Event Source Mapping Creation failed: Function: ${
           input.functionName
         } ${JSON.stringify(error)}`
       );
       if (error?.name === "ResourceConflictException") {
-        Logger.warn(
+        this.logger.warn(
           `Event Source Mapping already exists: Function: ${input.functionName}`
         );
         return;
@@ -67,7 +69,7 @@ export class LambdaClient {
     try {
       return await this.client.listEventSourceMappings(params);
     } catch (error) {
-      Logger.error(
+      this.logger.error(
         `Failed to list Event Source Mapping for Queue: ${queueARN}`
       );
       throw error;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,18 +1,24 @@
-export class Logger {
-  static logsEnabled = false;
-  static error(error: any) {
+import { Logger as LoggerI } from "../types";
+
+export class Logger implements LoggerI {
+  constructor(private readonly logsEnabled: boolean) {}
+
+  public error(error: any) {
     if(!this.logsEnabled) return;
     console.error(`EventBrokerLog ::: ${error}`);
   }
-  static warn(message: any) {
+
+  public warn(message: any) {
     if(!this.logsEnabled) return;
     console.warn(`EventBrokerLog ::: ${message}`);
   }
-  static debug(message: any) {
+
+  public debug(message: any) {
     if(!this.logsEnabled) return;
     console.debug(`EventBrokerLog ::: ${message}`);
   }
-  static info(message: any) {
+
+  public info(message: any) {
     if(!this.logsEnabled) return;
     console.info(`EventBrokerLog ::: ${message}`);
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,6 @@
-import { Logger as LoggerI } from "../types";
+import { Logger as ILogger } from "../types";
 
-export class Logger implements LoggerI {
+export class Logger implements ILogger {
   constructor(private readonly logsEnabled: boolean) {}
 
   public error(error: any) {


### PR DESCRIPTION
Fixed Failure Event Emitter Bug

Added Failure Type in emitted failure event

Renamed key in main handler to executionTraceId and started logging it wherever it was available and also throwing it with errors so that errors can be tied to events

Added support for external logger

External logger can now also provide async storage and store, and thus the logger can provide the context in which to call the handler functions ensuring same context throughout an attempt to process a message. This allows all logs made the service during its function call and by the event broker to be traced with a single trace execution id which is also emitted on failure event emitter so can also be found on slack

Ran npm audit fix due to vulnerabilities pointed out by npm as shown in image below

<img width="1004" alt="image" src="https://github.com/Rewaa-Team/event-broker/assets/31252332/dcb9e3a0-e755-4218-8a76-b806d44bc48d">
