### PR TITLE
Release/5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rewaa/event-broker",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rewaa/event-broker",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
         "sqs-consumer": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rewaa/event-broker",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A broker for all the events that Rewaa will ever produce or consume",
   "main": "dist/index.js",
   "scripts": {

--- a/src/emitters/emitter.sqns.ts
+++ b/src/emitters/emitter.sqns.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from 'async_hooks';
 import EventEmitter from "events";
 import { Consumer } from "sqs-consumer";
 import {
@@ -520,6 +519,8 @@ export class SqnsEmitter implements IEmitter {
   ) => {
     const executionContext: ProcessMessageContext = {
       executionTraceId: v4(),
+      messageId: message.MessageId,
+      receiptHandler: message.ReceiptHandle,
     };
     this.logger.info(
       `Message started ${queueUrl}_${executionContext.executionTraceId}_${new Date()}_${message?.Body?.toString()}`
@@ -634,7 +635,7 @@ export class SqnsEmitter implements IEmitter {
     try {
       for (const listener of listeners) {
         await listener(message.data, { 
-          executionTraceId: executionContext.executionTraceId,
+          executionContext,
           messageId: message.id,
           messageAttributes: message.messageAttributes,
          });

--- a/src/types.ts
+++ b/src/types.ts
@@ -326,7 +326,7 @@ export type DefaultQueueOptions = Omit<
 >;
 
 export interface MessageMetaData {
-  executionTraceId: string;
+  executionContext: ProcessMessageContext;
   messageId?: string;
   messageAttributes?: { [key: string]: MessageAttributeValue };
 }
@@ -505,4 +505,13 @@ export interface ProcessMessageContext {
    * and run it through all the listeners
    */
   executionTraceId: string;
+  /**
+   * @description Unique identifier for this message. Stays consistent across
+   * multiple attempts to process it
+   */
+  messageId?: string;
+  /**
+   * @description Similar to @see executionTraceId but provided by aws
+   */
+  receiptHandler?: string;
 }


### PR DESCRIPTION
Since the async context does not carry over the node event emitter (which does not come as a surprise but i had not thought of it previously) therefore i am emitting slightly more data in the failed event for context, and also added the same in the message attributes that are handed to listener functions. This will allow a service to correlated logs of multiple processing attempts of a message through the message id