### PR TITLE
feat: add ApproximateReceiveCount to the message attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rewaa/event-broker",
-  "version": "6.1.6",
+  "version": "6.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rewaa/event-broker",
-  "version": "6.1.6",
+  "version": "6.2.0",
   "description": "A broker for all the events that Rewaa will ever produce or consume",
   "main": "dist/index.js",
   "scripts": {

--- a/src/emitters/emitter.sqns.ts
+++ b/src/emitters/emitter.sqns.ts
@@ -789,6 +789,7 @@ export class SqnsEmitter implements IEmitter {
           executionContext,
           messageId: message.id,
           messageAttributes: message.messageAttributes,
+          approximateReceiveCount: this.getApproximateReceiveCount(receivedMessage),
         });
       }
       await this.options.hooks?.afterConsume?.(message.eventName, message.data);
@@ -820,7 +821,6 @@ export class SqnsEmitter implements IEmitter {
       receivedMessage.MessageAttributes ||
       (receivedMessage as any).messageAttributes ||
       message.messageAttributes; 
-    this.saveApproximateReceiveCount(receivedMessage, message);
     return message as IMessage<T>;
   }
 
@@ -999,17 +999,7 @@ export class SqnsEmitter implements IEmitter {
     const urlParts = queueUrl.split('/')
     return urlParts[urlParts.length - 1]
   }
-
-  private saveApproximateReceiveCount(receivedMessage: Message, message: IMessage<any>) {
-    const approximateRecievedCount = this.getApproximateReceiveCount(receivedMessage);
-    if (message.messageAttributes) {
-      message.messageAttributes['ApproximateReceiveCount'] = {
-        StringValue: approximateRecievedCount,
-        DataType: 'Number',
-      }
-    }
-  }
-
+ 
   private getApproximateReceiveCount(receivedMessage: Message) {
     return receivedMessage.Attributes?.ApproximateReceiveCount
         || (receivedMessage as any).attributes.ApproximateReceiveCount;

--- a/src/emitters/emitter.sqns.ts
+++ b/src/emitters/emitter.sqns.ts
@@ -557,11 +557,11 @@ export class SqnsEmitter implements IEmitter {
     this.logger.info(`Consumers started`);
   }
 
-  private startConsumer(queue: Queue) {
+  private addConsumerWorkerToQueue(queue: Queue) {
     if (!queue.url) {
       return;
     }
-    queue.consumer = Consumer.create({
+    const consumer = Consumer.create({
       /**
        * Handling delete message explcitly because sqs-consumer
        * does not delete the successful ones if one of the message
@@ -583,8 +583,8 @@ export class SqnsEmitter implements IEmitter {
       visibilityTimeout: queue.visibilityTimeout || DEFAULT_VISIBILITY_TIMEOUT,
     });
 
-    queue.consumer.on("error", (error, message) => {
-      this.logger.error(`Queue error ${queue.topic.name} ${queue.url} ${JSON.stringify(error)}`);
+    consumer.on("error", (error, message) => {
+      this.logger.error(`Queue error ${JSON.stringify(error)}`);
       this.logFailedEvent({
         failureType: FailedEventCategory.QueueError,
         topic: queue.topic.name,
@@ -594,7 +594,7 @@ export class SqnsEmitter implements IEmitter {
       });
     });
 
-    queue.consumer.on("processing_error", (error, message) => {
+    consumer.on("processing_error", (error, message) => {
       this.logger.error(`Queue Processing error ${JSON.stringify(error)}`);
       this.logFailedEvent({
         failureType: FailedEventCategory.QueueProcessingError,
@@ -604,7 +604,7 @@ export class SqnsEmitter implements IEmitter {
       });
     });
 
-    queue.consumer.on("stopped", () => {
+    consumer.on("stopped", () => {
       this.logger.error("Queue stopped");
       this.logFailedEvent({
         failureType: FailedEventCategory.QueueStopped,
@@ -613,7 +613,7 @@ export class SqnsEmitter implements IEmitter {
       });
     });
 
-    queue.consumer.on("timeout_error", () => {
+    consumer.on("timeout_error", () => {
       this.logger.error("Queue timed out");
       this.logFailedEvent({
         failureType: FailedEventCategory.QueueTimedOut,
@@ -622,12 +622,24 @@ export class SqnsEmitter implements IEmitter {
       });
     });
 
-    queue.consumer.on("empty", () => {
-      if (!queue.consumer?.isRunning) {
+    consumer.on("empty", () => {
+      if (!consumer?.isRunning) {
         this.logger.info(`Queue not running`);
       }
     });
-    queue.consumer.start();
+
+    consumer.start();
+
+    if (!queue.consumers?.length) {
+      queue.consumers = [];
+    }
+    queue.consumers.push(consumer);
+  }
+
+  private startConsumer(queue: Queue) {
+    for (let i = 0; i < (queue.workers ?? 1); i++) {
+      this.addConsumerWorkerToQueue(queue);
+    }
   }
 
   private handleMessageReceipt = async (
@@ -820,7 +832,7 @@ export class SqnsEmitter implements IEmitter {
     message.messageAttributes =
       receivedMessage.MessageAttributes ||
       (receivedMessage as any).messageAttributes ||
-      message.messageAttributes; 
+      message.messageAttributes;
     return message as IMessage<T>;
   }
 
@@ -999,7 +1011,7 @@ export class SqnsEmitter implements IEmitter {
     const urlParts = queueUrl.split('/')
     return urlParts[urlParts.length - 1]
   }
- 
+
   private getApproximateReceiveCount(receivedMessage: Message) {
     return receivedMessage.Attributes?.ApproximateReceiveCount
         || (receivedMessage as any).attributes.ApproximateReceiveCount;

--- a/src/emitters/emitter.sqns.ts
+++ b/src/emitters/emitter.sqns.ts
@@ -584,7 +584,7 @@ export class SqnsEmitter implements IEmitter {
     });
 
     consumer.on("error", (error, message) => {
-      this.logger.error(`Queue error ${JSON.stringify(error)}`);
+      this.logger.error(`Queue error ${queue.topic.name} ${queue.url} ${JSON.stringify(error)}`);
       this.logFailedEvent({
         failureType: FailedEventCategory.QueueError,
         topic: queue.topic.name,

--- a/src/emitters/emitter.sqns.ts
+++ b/src/emitters/emitter.sqns.ts
@@ -727,6 +727,7 @@ export class SqnsEmitter implements IEmitter {
         listenerIsLambda: !!topic.lambdaHandler,
         topic,
         allTopics: [topic],
+        workers: topic.workers,
       };
       this.queues.set(queueName, queue);
     } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,7 @@ export interface IFailedEventMessage {
 export interface Queue {
   name: string;
   isFifo: boolean;
-  consumer?: Consumer;
+  consumers?: Consumer[];
   url?: string;
   arn?: string;
   isDLQ?: boolean;
@@ -142,6 +142,7 @@ export interface Queue {
   listenerIsLambda?: boolean;
   topic: Topic;
   allTopics: Topic[];
+  workers?: number;
 }
 
 export interface Topic {

--- a/src/types.ts
+++ b/src/types.ts
@@ -251,6 +251,11 @@ export interface Topic {
    * Default value is false (off)
    */
   contentBasedDeduplication?: boolean;
+
+  /**
+   * The number of workers attached to this queue
+   */
+  workers?: number;
 }
 
 export interface Hooks {
@@ -386,6 +391,7 @@ export interface MessageMetaData {
   executionContext: ProcessMessageContext;
   messageId?: string;
   messageAttributes?: { [key: string]: MessageAttributeValue };
+  approximateReceiveCount?: number;
 }
 
 export type EventListener<T> = (args: T, metadata?: MessageMetaData) => Promise<void>;


### PR DESCRIPTION
1. Add the `ApproximateReceiveCount` option to the `attributeNames` for the `ConsumerOptions`.
2. Add the `approximateReceiveCount` from the `Attributes` to the `MessageMetadata`.
