### PR TITLE
feat: add filter policy on already created subscriber

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@rewaa/event-broker",
-  "version": "8.0.0",
+  "name": "@rewaa-team/event-broker",
+  "version": "9.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@rewaa/event-broker",
-      "version": "8.0.0",
+      "name": "@rewaa-team/event-broker",
+      "version": "9.0.2",
       "license": "ISC",
       "dependencies": {
         "eventemitter2": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rewaa-team/event-broker",
-  "version": "9.0.0",
+  "version": "9.0.2",
   "description": "A broker for all the events that Rewaa will ever produce or consume",
   "main": "dist/index.js",
   "scripts": {

--- a/src/producers/producer.sns.ts
+++ b/src/producers/producer.sns.ts
@@ -126,20 +126,24 @@ export class SNSProducer {
       Attributes: {}
     };
 
-    if (params.Attributes) {
-      if(filterPolicy) {
-        params.Attributes.FilterPolicy = JSON.stringify(filterPolicy);
-      }
-    }
-
     try {
       const response = await this.sns.subscribe(params);
       /**
-       * Always setting attributes after creating subscribtion
-       * This is done to avoid having to filter subscriptions to check
-       * if they exist
+       * Attributes are always set after creating the subscription rather than
+       * being passed to Subscribe. Subscribe is idempotent on the endpoint, so
+       * for an existing subscription it returns the same ARN without applying
+       * new attributes (and SNS/LocalStack reject re-subscribing with different
+       * attributes). Setting them here reconciles the FilterPolicy in place
+       * whether the subscription is newly created or already exists.
        */
       if(response.SubscriptionArn) {
+        if(filterPolicy) {
+        await this.sns.setSubscriptionAttributes({
+          SubscriptionArn: response.SubscriptionArn,
+          AttributeName: 'FilterPolicy',
+          AttributeValue: JSON.stringify(filterPolicy),
+        });
+      }
         if(deliverRawMessage) {
           await this.sns.setSubscriptionAttributes({
             SubscriptionArn: response.SubscriptionArn,

--- a/tests/filter-policy.integration.test.ts
+++ b/tests/filter-policy.integration.test.ts
@@ -1,0 +1,97 @@
+import {
+  GetSubscriptionAttributesCommand,
+  ListSubscriptionsByTopicCommand,
+  SNSClient,
+} from "@aws-sdk/client-sns";
+import { Emitter } from "../src/emitters/emitter";
+import { ExchangeType } from "../src/types";
+import { createTestEmitter } from "./helpers/emitter-factory";
+
+const snsClient = new SNSClient({
+  endpoint: "http://localhost:4566/",
+  region: "us-east-1",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+const getFilterPolicy = async (
+  topicArn: string,
+  queueArn: string
+): Promise<string | undefined> => {
+  const { Subscriptions } = await snsClient.send(
+    new ListSubscriptionsByTopicCommand({ TopicArn: topicArn })
+  );
+  const sub = (Subscriptions ?? []).find((s) => s.Endpoint === queueArn);
+  if (!sub?.SubscriptionArn) return undefined;
+  const { Attributes } = await snsClient.send(
+    new GetSubscriptionAttributesCommand({
+      SubscriptionArn: sub.SubscriptionArn,
+    })
+  );
+  return Attributes?.FilterPolicy;
+};
+
+describe("FilterPolicy reconciliation on existing subscription - Integration", () => {
+  let emitter: Emitter;
+
+  afterAll(() => {
+    emitter.removeAllListener();
+  });
+
+  it("updates the FilterPolicy when re-subscribing an existing subscription", async () => {
+    const eventName = "FilterPolicyReconcileEvent";
+
+    // First bootstrap creates the subscription with an initial policy.
+    const first = createTestEmitter("filter-policy-service");
+    first.on(
+      eventName,
+      async () => undefined,
+      {
+        isFifo: false,
+        exchangeType: ExchangeType.Fanout,
+        deadLetterQueueEnabled: true,
+        separateConsumerGroup: "filter_policy_consumer",
+        filterPolicy: { tenantId: ["tenant-1"] },
+      }
+    );
+    await first.bootstrap();
+
+    const topicArn = first.getTopicReference({
+      name: eventName,
+      isFifo: false,
+      exchangeType: ExchangeType.Fanout,
+    });
+    const queueArn = first.getQueueReference({
+      name: eventName,
+      isFifo: false,
+      exchangeType: ExchangeType.Fanout,
+      separateConsumerGroup: "filter_policy_consumer",
+    });
+
+    expect(JSON.parse((await getFilterPolicy(topicArn, queueArn))!)).toEqual({
+      tenantId: ["tenant-1"],
+    });
+
+    // Second bootstrap on the SAME subscription with a DIFFERENT policy.
+    // Previously this threw "Subscription already exists with different
+    // attributes"; now it must reconcile the policy in place.
+    emitter = createTestEmitter("filter-policy-service");
+    emitter.on(
+      eventName,
+      async () => undefined,
+      {
+        isFifo: false,
+        exchangeType: ExchangeType.Fanout,
+        deadLetterQueueEnabled: true,
+        separateConsumerGroup: "filter_policy_consumer",
+        filterPolicy: { tenantId: ["tenant-1", "tenant-2"] },
+      }
+    );
+    await expect(emitter.bootstrap()).resolves.not.toThrow();
+
+    expect(JSON.parse((await getFilterPolicy(topicArn, queueArn))!)).toEqual({
+      tenantId: ["tenant-1", "tenant-2"],
+    });
+
+    first.removeAllListener();
+  });
+});


### PR DESCRIPTION
## Problem

When a `filterPolicy` was added to a topic that already had an existing SNS subscription, `bootstrap()` would fail with:

```
Topic subscription failed: <queue-arn> to <topic-arn>
Subscription already exists with different attributes
```

This happened because `FilterPolicy` was being passed as an `Attributes` field in the `Subscribe` call. SNS `Subscribe` is idempotent on the endpoint — for an existing subscription it returns the same ARN without applying new attributes, and LocalStack actively rejects re-subscribing with different attributes.

## Fix

Moved `FilterPolicy` out of the `Subscribe` call and into a `SetSubscriptionAttributes` call that always runs after `subscribe()`. This reconciles the policy in place whether the subscription is newly created or already exists — so adding or updating a `filterPolicy` on any topic works on every `bootstrap()` run without any per-service workaround.

**Changed file:** `src/producers/producer.sns.ts` → `subscribeToTopic()`

## Testing

Added `tests/filter-policy.integration.test.ts` which:
1. Bootstraps a Fanout topic with `filterPolicy: { tenantId: ["tenant-1"] }`
2. Bootstraps the **same** topic again with `filterPolicy: { tenantId: ["tenant-1", "tenant-2"] }`
3. Asserts the second bootstrap does not throw and the updated policy is applied on the existing subscription

All 6 integration test suites (11 tests) pass against LocalStack.